### PR TITLE
Change to forked version of mgo

### DIFF
--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
-	"gopkg.in/mgo.v2"
+	"github.com/globalsign/mgo"
 )
 
 var session *mgo.Session


### PR DESCRIPTION
Change to forked version of mgo, as the original version is no longer maintained.

https://github.com/globalsign/mgo
https://github.com/go-mgo/mgo/tree/v2-unstable