### PR TITLE
Return 201 for successfully created resource

### DIFF
--- a/service/payment.go
+++ b/service/payment.go
@@ -79,10 +79,10 @@ func (service *PaymentService) CreatePaymentSession(w http.ResponseWriter, req *
 
 	// Add data to response
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
 	err = json.NewEncoder(w).Encode(paymentResource)
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error writing response: %v", err))
-		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -140,7 +140,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
 
 		mockPaymentService.CreatePaymentSession(w, req)
-		So(w.Code, ShouldEqual, 200)
+		So(w.Code, ShouldEqual, 201)
 	})
 
 }


### PR DESCRIPTION
Write 201 status for successfully created resource.
The Encode method sets 200 if not already set, so set the 201 before this line.
Also removed the 501 header, as the status can only be set once.