### PR TITLE
Add "Get Payment Session" endpoint

### DIFF
--- a/dao/dao.go
+++ b/dao/dao.go
@@ -5,5 +5,5 @@ import "github.com/companieshouse/payments.api.ch.gov.uk/models"
 // DAO is an interface for accessing dao from a backend store
 type DAO interface {
 	CreatePaymentResource(paymentResource *models.PaymentResource) error
-	GetPaymentResource(string) (models.PaymentResource, error)
+	GetPaymentResource(string) (*models.PaymentResource, error)
 }

--- a/dao/dao.go
+++ b/dao/dao.go
@@ -4,5 +4,6 @@ import "github.com/companieshouse/payments.api.ch.gov.uk/models"
 
 // DAO is an interface for accessing dao from a backend store
 type DAO interface {
-	CreatePaymentResourceDB(paymentResource *models.PaymentResource) error
+	CreatePaymentResource(paymentResource *models.PaymentResource) error
+	GetPaymentResource(string) (models.PaymentResource, error)
 }

--- a/dao/mock_dao.go
+++ b/dao/mock_dao.go
@@ -33,14 +33,27 @@ func (m *MockDAO) EXPECT() *MockDAOMockRecorder {
 	return m.recorder
 }
 
-// CreatePaymentResourceDB mocks base method
-func (m *MockDAO) CreatePaymentResourceDB(paymentResource *models.PaymentResource) error {
-	ret := m.ctrl.Call(m, "CreatePaymentResourceDB", paymentResource)
+// CreatePaymentResource mocks base method
+func (m *MockDAO) CreatePaymentResource(paymentResource *models.PaymentResource) error {
+	ret := m.ctrl.Call(m, "CreatePaymentResource", paymentResource)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CreatePaymentResourceDB indicates an expected call of CreatePaymentResourceDB
-func (mr *MockDAOMockRecorder) CreatePaymentResourceDB(paymentResource interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePaymentResourceDB", reflect.TypeOf((*MockDAO)(nil).CreatePaymentResourceDB), paymentResource)
+// CreatePaymentResource indicates an expected call of CreatePaymentResource
+func (mr *MockDAOMockRecorder) CreatePaymentResource(paymentResource interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePaymentResource", reflect.TypeOf((*MockDAO)(nil).CreatePaymentResource), paymentResource)
+}
+
+// GetPaymentResource mocks base method
+func (m *MockDAO) GetPaymentResource(arg0 string) (models.PaymentResource, error) {
+	ret := m.ctrl.Call(m, "GetPaymentResource", arg0)
+	ret0, _ := ret[0].(models.PaymentResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPaymentResource indicates an expected call of GetPaymentResource
+func (mr *MockDAOMockRecorder) GetPaymentResource(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentResource", reflect.TypeOf((*MockDAO)(nil).GetPaymentResource), arg0)
 }

--- a/dao/mock_dao.go
+++ b/dao/mock_dao.go
@@ -46,9 +46,9 @@ func (mr *MockDAOMockRecorder) CreatePaymentResource(paymentResource interface{}
 }
 
 // GetPaymentResource mocks base method
-func (m *MockDAO) GetPaymentResource(arg0 string) (models.PaymentResource, error) {
+func (m *MockDAO) GetPaymentResource(arg0 string) (*models.PaymentResource, error) {
 	ret := m.ctrl.Call(m, "GetPaymentResource", arg0)
-	ret0, _ := ret[0].(models.PaymentResource)
+	ret0, _ := ret[0].(*models.PaymentResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -31,9 +31,8 @@ func getMongoSession() (*mgo.Session, error) {
 	return session.Copy(), nil
 }
 
-// CreatePaymentResourceDB writes a new payment resource to the DB
-func (m *Mongo) CreatePaymentResourceDB(paymentResource *models.PaymentResource) error {
-
+// CreatePaymentResource writes a new payment resource to the DB
+func (m *Mongo) CreatePaymentResource(paymentResource *models.PaymentResource) error {
 	paymentSession, err := getMongoSession()
 	if err != nil {
 		return err
@@ -43,5 +42,19 @@ func (m *Mongo) CreatePaymentResourceDB(paymentResource *models.PaymentResource)
 	c := paymentSession.DB("payments").C("payments")
 
 	return c.Insert(paymentResource)
+}
 
+// GetPaymentResource gets a payment resource from the DB
+func (m *Mongo) GetPaymentResource(id string) (models.PaymentResource, error) {
+	var resource models.PaymentResource
+	paymentSession, err := getMongoSession()
+	if err != nil {
+		return resource, err
+	}
+	defer paymentSession.Close()
+
+	c := paymentSession.DB("payments").C("payments")
+	err = c.FindId(id).One(&resource)
+
+	return resource, err
 }

--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -45,16 +45,21 @@ func (m *Mongo) CreatePaymentResource(paymentResource *models.PaymentResource) e
 }
 
 // GetPaymentResource gets a payment resource from the DB
-func (m *Mongo) GetPaymentResource(id string) (models.PaymentResource, error) {
+func (m *Mongo) GetPaymentResource(id string) (*models.PaymentResource, error) {
 	var resource models.PaymentResource
 	paymentSession, err := getMongoSession()
 	if err != nil {
-		return resource, err
+		return nil, err
 	}
 	defer paymentSession.Close()
 
 	c := paymentSession.DB("payments").C("payments")
 	err = c.FindId(id).One(&resource)
 
-	return resource, err
+	// If Payment not found in DB, return empty resource
+	if err != nil && err != mgo.ErrNotFound {
+		return nil, err
+	}
+
+	return &resource, err
 }

--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -45,11 +45,12 @@ func (m *Mongo) CreatePaymentResource(paymentResource *models.PaymentResource) e
 }
 
 // GetPaymentResource gets a payment resource from the DB
+// If payment not found in DB, return nil
 func (m *Mongo) GetPaymentResource(id string) (*models.PaymentResource, error) {
 	var resource models.PaymentResource
 	paymentSession, err := getMongoSession()
 	if err != nil {
-		return nil, err
+		return &resource, err
 	}
 	defer paymentSession.Close()
 
@@ -57,8 +58,8 @@ func (m *Mongo) GetPaymentResource(id string) (*models.PaymentResource, error) {
 	err = c.FindId(id).One(&resource)
 
 	// If Payment not found in DB, return empty resource
-	if err != nil && err != mgo.ErrNotFound {
-		return nil, err
+	if err != nil && err == mgo.ErrNotFound {
+		return nil, nil
 	}
 
 	return &resource, err

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -21,6 +21,7 @@ func Register(r *pat.Router, cfg config.Config) {
 
 	r.Get("/healthcheck", healthCheck).Name("get-healthcheck")
 	r.Post("/payments", p.CreatePaymentSession).Name("create-payment")
+	r.Get("/payments/{payment_id}", p.GetPaymentSession).Name("get-payment")
 	r.Patch("/private/payments/{payment_id}", service.CreateExternalPaymentJourney).Name("create-payment-journey")
 }
 

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -18,6 +18,7 @@ func TestUnitRegisterRoutes(t *testing.T) {
 		Register(router, *cfg)
 		So(router.GetRoute("get-healthcheck"), ShouldNotBeNil)
 		So(router.GetRoute("create-payment"), ShouldNotBeNil)
+		So(router.GetRoute("get-payment"), ShouldNotBeNil)
 		So(router.GetRoute("create-payment-journey"), ShouldNotBeNil)
 	})
 }

--- a/models/payment.go
+++ b/models/payment.go
@@ -12,17 +12,19 @@ type IncomingPaymentResourceRequest struct {
 
 // PaymentResource is the payment details to be stored in the DB and returned in the response
 type PaymentResource struct {
-	ID                      string    `json:"_id"                                 bson:"_id"`
-	Amount                  string    `json:"amount"                              bson:"amount"`
-	AvailablePaymentMethods []string  `json:"available_payment_methods,omitempty" bson:"available_payment_methods,omitempty"`
-	CompletedAt             time.Time `json:"completed_at,omitempty"              bson:"completed_at,omitempty"`
-	CreatedAt               time.Time `json:"created_at,omitempty"                bson:"created_at,omitempty"`
-	CreatedBy               CreatedBy `json:"created_by"                          bson:"created_by"`
-	Description             string    `json:"description"                         bson:"description"`
-	Links                   Links     `json:"links"                               bson:"links"`
-	PaymentMethod           string    `json:"payment_method,omitempty"            bson:"payment_method,omitempty"`
-	Reference               string    `json:"reference,omitempty"                 bson:"reference,omitempty"`
-	Status                  string    `json:"status"                              bson:"status"`
+	ID                      string         `json:"_id"                                 bson:"_id"`
+	Amount                  string         `json:"amount"                              bson:"amount"`
+	AvailablePaymentMethods []string       `json:"available_payment_methods,omitempty" bson:"available_payment_methods,omitempty"`
+	CompletedAt             time.Time      `json:"completed_at,omitempty"              bson:"completed_at,omitempty"`
+	CreatedAt               time.Time      `json:"created_at,omitempty"                bson:"created_at,omitempty"`
+	CreatedBy               CreatedBy      `json:"created_by"                          bson:"created_by"`
+	Description             string         `json:"description"                         bson:"description"`
+	Links                   Links          `json:"links"                               bson:"links"`
+	PaymentMethod           string         `json:"payment_method,omitempty"            bson:"payment_method,omitempty"`
+	RedirectURI             string         `json:"redirect_uri"                        bson:"redirect_uri"`
+	Reference               string         `json:"reference,omitempty"                 bson:"reference,omitempty"`
+	Status                  string         `json:"status"                              bson:"status"`
+	Costs                   []CostResource `json:"items"`
 }
 
 // CreatedBy is the user who is creating the payment session
@@ -49,4 +51,20 @@ type Data struct {
 // Filing is a representation of the Filing subsection of data retrieved from the Transaction API
 type Filing struct {
 	Description string `json:"description"`
+}
+
+// CostResource contains the details of an individual Cost Resource
+type CostResource struct {
+	Amount                  string            `json:"amount"`
+	AvailablePaymentMethods []string          `json:"available_payment_methods"`
+	ClassOfPayment          []string          `json:"class_of_payment"`
+	Description             string            `json:"description"`
+	DescriptionIdentifier   string            `json:"description_identifier"`
+	DescriptionValues       DescriptionValues `json:"description_values"`
+	IsVariablePayment       bool              `json:"is_variable_payment"`
+	Links                   Links             `json:"links"`
+}
+
+// DescriptionValues contains a description of the cost
+type DescriptionValues struct {
 }

--- a/routes.yaml
+++ b/routes.yaml
@@ -3,5 +3,6 @@ group: api
 # XXX Make sure all services with /transaction/ based routes have a weight LOWER than 1000	
 weight: 900	
 routes:	
-   1: ^/payments
-   2: ^/private/payments/.*
+  1: ^/payments
+  2: ^/payments/.*
+  3: ^/private/payments/.*

--- a/service/payment.go
+++ b/service/payment.go
@@ -132,14 +132,7 @@ func (service *PaymentService) GetPaymentSession(w http.ResponseWriter, req *htt
 		return
 	}
 
-	cfg, err := config.Get()
-	if err != nil {
-		log.ErrorR(req, fmt.Errorf("error getting config: [%v]", err))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	costs, err := getCosts(w, req, paymentResource.Links.Resource, cfg)
+	costs, err := getCosts(w, req, paymentResource.Links.Resource, &service.Config)
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error getting payment resource: [%v]", err))
 		return

--- a/service/payment.go
+++ b/service/payment.go
@@ -15,7 +15,6 @@ import (
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
 	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
-	"github.com/globalsign/mgo"
 )
 
 // PaymentService contains the DAO for db access
@@ -122,7 +121,7 @@ func (service *PaymentService) GetPaymentSession(w http.ResponseWriter, req *htt
 
 	paymentResource, err := service.DAO.GetPaymentResource(id)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if paymentResource != nil {
 			log.Info(fmt.Sprintf("payment session not found. id: %s", id))
 			w.WriteHeader(http.StatusForbidden)
 			return

--- a/service/payment.go
+++ b/service/payment.go
@@ -120,12 +120,12 @@ func (service *PaymentService) GetPaymentSession(w http.ResponseWriter, req *htt
 	}
 
 	paymentResource, err := service.DAO.GetPaymentResource(id)
+	if paymentResource == nil {
+		log.Info(fmt.Sprintf("payment session not found. id: %s", id))
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
 	if err != nil {
-		if paymentResource != nil {
-			log.Info(fmt.Sprintf("payment session not found. id: %s", id))
-			w.WriteHeader(http.StatusForbidden)
-			return
-		}
 		log.ErrorR(req, fmt.Errorf("error getting payment resource from db: [%v]", err))
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -237,7 +237,7 @@ func TestUnitGetPayment(t *testing.T) {
 	Convey("Payment ID not found", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
-		mock.EXPECT().GetPaymentResource("invalid").Return(models.PaymentResource{}, mgo.ErrNotFound)
+		mock.EXPECT().GetPaymentResource("invalid").Return(&models.PaymentResource{}, mgo.ErrNotFound)
 		req, err := http.NewRequest("Get", "", nil)
 		q := req.URL.Query()
 		q.Add(":payment_id", "invalid")
@@ -251,7 +251,7 @@ func TestUnitGetPayment(t *testing.T) {
 	Convey("Error getting payment from DB", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
-		mock.EXPECT().GetPaymentResource("1234").Return(models.PaymentResource{}, fmt.Errorf("error"))
+		mock.EXPECT().GetPaymentResource("1234").Return(nil, fmt.Errorf("error"))
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)
 		q := req.URL.Query()
@@ -265,7 +265,7 @@ func TestUnitGetPayment(t *testing.T) {
 	Convey("Error getting payment resource", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
-		mock.EXPECT().GetPaymentResource("1234").Return(models.PaymentResource{}, nil)
+		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResource{}, nil)
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)
 		q := req.URL.Query()
@@ -282,7 +282,7 @@ func TestUnitGetPayment(t *testing.T) {
 	Convey("Invalid cost", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
-		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(models.PaymentResource{Amount: "x", Links: models.Links{Resource: "http://dummy-resource"}}, nil)
+		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResource{Amount: "x", Links: models.Links{Resource: "http://dummy-resource"}}, nil)
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
@@ -304,7 +304,7 @@ func TestUnitGetPayment(t *testing.T) {
 	Convey("Amount mismatch", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
-		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(models.PaymentResource{Amount: "100", Links: models.Links{Resource: "http://dummy-resource"}}, nil)
+		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResource{Amount: "100", Links: models.Links{Resource: "http://dummy-resource"}}, nil)
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
@@ -324,7 +324,7 @@ func TestUnitGetPayment(t *testing.T) {
 	Convey("Get Payment session - success - Single cost", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
-		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(models.PaymentResource{Amount: "10", Links: models.Links{Resource: "http://dummy-resource"}}, nil)
+		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResource{Amount: "10", Links: models.Links{Resource: "http://dummy-resource"}}, nil)
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
@@ -344,7 +344,7 @@ func TestUnitGetPayment(t *testing.T) {
 	Convey("Get Payment session - success - Multiple costs", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
-		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(models.PaymentResource{Amount: "23", Links: models.Links{Resource: "http://dummy-resource"}}, nil)
+		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResource{Amount: "23", Links: models.Links{Resource: "http://dummy-resource"}}, nil)
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
 	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
-	"github.com/globalsign/mgo"
 	"github.com/golang/mock/gomock"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/jarcoal/httpmock.v1"
@@ -237,7 +236,7 @@ func TestUnitGetPayment(t *testing.T) {
 	Convey("Payment ID not found", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
-		mock.EXPECT().GetPaymentResource("invalid").Return(&models.PaymentResource{}, mgo.ErrNotFound)
+		mock.EXPECT().GetPaymentResource("invalid").Return(nil, nil)
 		req, err := http.NewRequest("Get", "", nil)
 		q := req.URL.Query()
 		q.Add(":payment_id", "invalid")
@@ -251,7 +250,7 @@ func TestUnitGetPayment(t *testing.T) {
 	Convey("Error getting payment from DB", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
-		mock.EXPECT().GetPaymentResource("1234").Return(nil, fmt.Errorf("error"))
+		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResource{}, fmt.Errorf("error"))
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)
 		q := req.URL.Query()

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
 	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
+	"github.com/globalsign/mgo"
 	"github.com/golang/mock/gomock"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/jarcoal/httpmock.v1"
@@ -55,7 +56,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		So(err, ShouldBeNil)
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
 		w := httptest.NewRecorder()
-		getPaymentResource(w, req, "http://dummy-resource", cfg)
+		getCosts(w, req, "http://dummy-resource", cfg)
 		So(w.Code, ShouldEqual, 400)
 	})
 
@@ -82,7 +83,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("GET", "http://dummy-resource", httpmock.NewStringResponder(500, "string"))
-		getPaymentResource(w, req, "http://dummy-resource", cfg)
+		getCosts(w, req, "http://dummy-resource", cfg)
 		So(w.Code, ShouldEqual, 500)
 	})
 
@@ -95,8 +96,8 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		w := httptest.NewRecorder()
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		var paymentResource models.IncomingPaymentResourceRequest
-		jsonResponse, _ := httpmock.NewJsonResponder(500, paymentResource)
+		var costArray []models.CostResource
+		jsonResponse, _ := httpmock.NewJsonResponder(500, costArray)
 		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
 		mockPaymentService.CreatePaymentSession(w, req)
 		So(w.Code, ShouldEqual, 500)
@@ -105,7 +106,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 	Convey("Error Creating DB Resource", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
-		mock.EXPECT().CreatePaymentResourceDB(gomock.Any()).Return(fmt.Errorf("error"))
+		mock.EXPECT().CreatePaymentResource(gomock.Any()).Return(fmt.Errorf("error"))
 
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)
@@ -116,8 +117,8 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		var paymentResource models.PaymentResource
-		jsonResponse, _ := httpmock.NewJsonResponder(200, paymentResource)
+		var costArray []models.CostResource
+		jsonResponse, _ := httpmock.NewJsonResponder(200, costArray)
 		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
 
 		mockPaymentService.CreatePaymentSession(w, req)
@@ -126,10 +127,10 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 
 	cfg.PaymentsWebURL = "https://payments.companieshouse.gov.uk"
 
-	Convey("Valid request", t, func() {
+	Convey("Valid request - single cost", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
-		mock.EXPECT().CreatePaymentResourceDB(gomock.Any())
+		mock.EXPECT().CreatePaymentResource(gomock.Any())
 
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)
@@ -140,8 +141,37 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		var paymentResource models.PaymentResource
-		jsonResponse, _ := httpmock.NewJsonResponder(200, paymentResource)
+		var costArray []models.CostResource
+		jsonResponse, _ := httpmock.NewJsonResponder(200, costArray)
+		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		mockPaymentService.CreatePaymentSession(w, req)
+		So(w.Code, ShouldEqual, 201)
+		responseByteArray := w.Body.Bytes()
+		var createdPaymentResource models.PaymentResource
+		if err := json.Unmarshal(responseByteArray, &createdPaymentResource); err != nil {
+			panic(err)
+		}
+		So(createdPaymentResource.ID, ShouldNotBeEmpty)
+		So(createdPaymentResource.Links.Journey, ShouldNotBeEmpty)
+		expectedJourneyURL := fmt.Sprintf("https://payments.companieshouse.gov.uk/payments/%s/pay", createdPaymentResource.ID)
+		So(createdPaymentResource.Links.Journey, ShouldEqual, expectedJourneyURL)
+		So(w.Header().Get("Location"), ShouldEqual, expectedJourneyURL)
+		So(createdPaymentResource.CreatedBy, ShouldNotBeEmpty)
+	})
+
+	Convey("Valid request - multiple costs", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+		mock.EXPECT().CreatePaymentResource(gomock.Any())
+		req, err := http.NewRequest("Get", "", nil)
+		So(err, ShouldBeNil)
+		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
+		req.Header.Set("Eric-Authorised-User", "test@companieshouse.gov.uk; forename=f; surname=s")
+		w := httptest.NewRecorder()
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		costArray := []models.CostResource{{Amount: "10"}, {Amount: "12"}}
+		jsonResponse, _ := httpmock.NewJsonResponder(200, costArray)
 		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
 
 		mockPaymentService.CreatePaymentSession(w, req)
@@ -172,4 +202,116 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		So(re.MatchString(generatedID), ShouldEqual, true)
 	})
 
+}
+
+func TestUnitGetPayment(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	cfg, _ := config.Get()
+
+	Convey("Payment ID missing", t, func() {
+		mockPaymentService := createMockPaymentService(dao.NewMockDAO(mockCtrl), cfg)
+		req, err := http.NewRequest("Get", "", nil)
+		So(err, ShouldBeNil)
+		w := httptest.NewRecorder()
+		mockPaymentService.GetPaymentSession(w, req)
+		So(w.Code, ShouldEqual, 400)
+	})
+	Convey("Payment ID not found", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+		mock.EXPECT().GetPaymentResource("invalid").Return(models.PaymentResource{}, mgo.ErrNotFound)
+		req, err := http.NewRequest("Get", "", nil)
+		q := req.URL.Query()
+		q.Add(":payment_id", "invalid")
+		req.URL.RawQuery = q.Encode()
+		So(err, ShouldBeNil)
+		w := httptest.NewRecorder()
+		mockPaymentService.GetPaymentSession(w, req)
+		So(w.Code, ShouldEqual, 403)
+	})
+	Convey("Error getting payment from DB", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+		mock.EXPECT().GetPaymentResource("1234").Return(models.PaymentResource{}, fmt.Errorf("error"))
+		req, err := http.NewRequest("Get", "", nil)
+		So(err, ShouldBeNil)
+		q := req.URL.Query()
+		q.Add(":payment_id", "1234")
+		req.URL.RawQuery = q.Encode()
+		w := httptest.NewRecorder()
+		mockPaymentService.GetPaymentSession(w, req)
+		So(w.Code, ShouldEqual, 500)
+	})
+	Convey("Error getting payment resource", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+		mock.EXPECT().GetPaymentResource("1234").Return(models.PaymentResource{}, nil)
+		req, err := http.NewRequest("Get", "", nil)
+		So(err, ShouldBeNil)
+		q := req.URL.Query()
+		q.Add(":payment_id", "1234")
+		req.URL.RawQuery = q.Encode()
+		w := httptest.NewRecorder()
+		mockPaymentService.GetPaymentSession(w, req)
+		So(w.Code, ShouldEqual, 400)
+	})
+	cfg.DomainWhitelist = "http://dummy-resource"
+	reqBody := []byte("{\"redirect_uri\": \"dummy-redirect-uri\",\"resource\": \"http://dummy-resource\",\"state\": \"dummy-state\",\"reference\": \"dummy-reference\"}")
+	Convey("Amount mismatch", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(models.PaymentResource{Amount: "100", Links: models.Links{Resource: "http://dummy-resource"}}, nil)
+		req, err := http.NewRequest("Get", "", nil)
+		So(err, ShouldBeNil)
+		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
+		q := req.URL.Query()
+		q.Add(":payment_id", "1234")
+		req.URL.RawQuery = q.Encode()
+		w := httptest.NewRecorder()
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		costArray := []models.CostResource{{Amount: "99"}}
+		jsonResponse, _ := httpmock.NewJsonResponder(200, costArray)
+		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		mockPaymentService.GetPaymentSession(w, req)
+		So(w.Code, ShouldEqual, 403)
+	})
+	Convey("Get Payment session - success - Single cost", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(models.PaymentResource{Amount: "10", Links: models.Links{Resource: "http://dummy-resource"}}, nil)
+		req, err := http.NewRequest("Get", "", nil)
+		So(err, ShouldBeNil)
+		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
+		q := req.URL.Query()
+		q.Add(":payment_id", "1234")
+		req.URL.RawQuery = q.Encode()
+		w := httptest.NewRecorder()
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		costArray := []models.CostResource{{Amount: "10"}}
+		jsonResponse, _ := httpmock.NewJsonResponder(200, costArray)
+		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		mockPaymentService.GetPaymentSession(w, req)
+		So(w.Code, ShouldEqual, 200)
+	})
+	Convey("Get Payment session - success - Multiple costs", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(models.PaymentResource{Amount: "23", Links: models.Links{Resource: "http://dummy-resource"}}, nil)
+		req, err := http.NewRequest("Get", "", nil)
+		So(err, ShouldBeNil)
+		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
+		q := req.URL.Query()
+		q.Add(":payment_id", "1234")
+		req.URL.RawQuery = q.Encode()
+		w := httptest.NewRecorder()
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		costArray := []models.CostResource{{Amount: "10"}, {Amount: "13"}}
+		jsonResponse, _ := httpmock.NewJsonResponder(200, costArray)
+		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		mockPaymentService.GetPaymentSession(w, req)
+		So(w.Code, ShouldEqual, 200)
+	})
 }

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -362,10 +362,19 @@ func TestUnitGetPayment(t *testing.T) {
 }
 
 func TestUnitGetTotalAmount(t *testing.T) {
-	Convey("Get Total Amount", t, func() {
-		costs := []models.CostResource{{Amount: "10"}, {Amount: "13"}}
+	Convey("Get Total Amount - valid", t, func() {
+		costs := []models.CostResource{{Amount: "10"}, {Amount: "13"}, {Amount: "13.01"}}
 		amount, err := getTotalAmount(&costs)
 		So(err, ShouldBeNil)
-		So(amount, ShouldEqual, "23")
+		So(amount, ShouldEqual, "36.01")
 	})
+	Convey("Test invalid amounts", t, func() {
+		invalidAmounts := []string{"alpha", "12,", "12.", "12,00", "12.012", "a.9", "9.a"}
+		for _, amount := range invalidAmounts {
+			totalAmount, err := getTotalAmount(&[]models.CostResource{{Amount: amount}})
+			So(totalAmount, ShouldEqual, "")
+			So(err.Error(), ShouldEqual, fmt.Sprintf("amount [%s] format incorrect", amount))
+		}
+	})
+
 }


### PR DESCRIPTION
This endpoint:

1. Receives a GET request for an existing Payment ID.
2. Gets the address of the Payment Resource from the DB.
3. Calls the Payment Resource to get the payment details.
4. Returns the Payment Resource, including an array of costs.

Resolves:
CPS-178