### PR TITLE
Add Patch Request and refactored GetPayment to be internal function

### DIFF
--- a/dao/dao.go
+++ b/dao/dao.go
@@ -6,5 +6,5 @@ import "github.com/companieshouse/payments.api.ch.gov.uk/models"
 type DAO interface {
 	CreatePaymentResource(paymentResource *models.PaymentResource) error
 	GetPaymentResource(string) (*models.PaymentResource, error)
-	PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) error
+	PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) (error, int)
 }

--- a/dao/dao.go
+++ b/dao/dao.go
@@ -6,5 +6,5 @@ import "github.com/companieshouse/payments.api.ch.gov.uk/models"
 type DAO interface {
 	CreatePaymentResource(paymentResource *models.PaymentResource) error
 	GetPaymentResource(string) (*models.PaymentResource, error)
-	PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) (error, int)
+	PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) error
 }

--- a/dao/dao.go
+++ b/dao/dao.go
@@ -6,4 +6,5 @@ import "github.com/companieshouse/payments.api.ch.gov.uk/models"
 type DAO interface {
 	CreatePaymentResource(paymentResource *models.PaymentResource) error
 	GetPaymentResource(string) (*models.PaymentResource, error)
+	PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) error
 }

--- a/dao/mock_dao.go
+++ b/dao/mock_dao.go
@@ -59,11 +59,10 @@ func (mr *MockDAOMockRecorder) GetPaymentResource(arg0 interface{}) *gomock.Call
 }
 
 // PatchPaymentResource mocks base method
-func (m *MockDAO) PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) (error, int) {
+func (m *MockDAO) PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) error {
 	ret := m.ctrl.Call(m, "PatchPaymentResource", id, paymentUpdate)
 	ret0, _ := ret[0].(error)
-	ret1, _ := ret[1].(int)
-	return ret0, ret1
+	return ret0
 }
 
 // PatchPaymentResource indicates an expected call of PatchPaymentResource

--- a/dao/mock_dao.go
+++ b/dao/mock_dao.go
@@ -5,10 +5,9 @@
 package dao
 
 import (
-	reflect "reflect"
-
 	models "github.com/companieshouse/payments.api.ch.gov.uk/models"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockDAO is a mock of DAO interface
@@ -36,7 +35,7 @@ func (m *MockDAO) EXPECT() *MockDAOMockRecorder {
 
 // CreatePaymentResource mocks base method
 func (m *MockDAO) CreatePaymentResource(paymentResource *models.PaymentResource) error {
-	ret := m.ctrl.Call(m, "CreatePaymentResource", paymentResource.Data)
+	ret := m.ctrl.Call(m, "CreatePaymentResource", paymentResource)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -57,4 +56,16 @@ func (m *MockDAO) GetPaymentResource(arg0 string) (*models.PaymentResource, erro
 // GetPaymentResource indicates an expected call of GetPaymentResource
 func (mr *MockDAOMockRecorder) GetPaymentResource(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentResource", reflect.TypeOf((*MockDAO)(nil).GetPaymentResource), arg0)
+}
+
+// PatchPaymentResource mocks base method
+func (m *MockDAO) PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) error {
+	ret := m.ctrl.Call(m, "PatchPaymentResource", id, paymentUpdate)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchPaymentResource indicates an expected call of PatchPaymentResource
+func (mr *MockDAOMockRecorder) PatchPaymentResource(id, paymentUpdate interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchPaymentResource", reflect.TypeOf((*MockDAO)(nil).PatchPaymentResource), id, paymentUpdate)
 }

--- a/dao/mock_dao.go
+++ b/dao/mock_dao.go
@@ -59,10 +59,11 @@ func (mr *MockDAOMockRecorder) GetPaymentResource(arg0 interface{}) *gomock.Call
 }
 
 // PatchPaymentResource mocks base method
-func (m *MockDAO) PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) error {
+func (m *MockDAO) PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) (error, int) {
 	ret := m.ctrl.Call(m, "PatchPaymentResource", id, paymentUpdate)
 	ret0, _ := ret[0].(error)
-	return ret0
+	ret1, _ := ret[1].(int)
+	return ret0, ret1
 }
 
 // PatchPaymentResource indicates an expected call of PatchPaymentResource

--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -78,12 +78,16 @@ func (m *Mongo) PatchPaymentResource(id string, paymentUpdate *models.PaymentRes
 
 	patchUpdate := make(bson.M)
 
-	// Patch only these fields
-	if paymentUpdate.PaymentMethod != "" {
-		patchUpdate["data.payment_method"] = paymentUpdate.PaymentMethod
-	}
-	if paymentUpdate.Status != "" {
-		patchUpdate["data.status"] = paymentUpdate.Status
+	if paymentUpdate.PaymentMethod != "" || paymentUpdate.Status != "" {
+		// Patch only these fields
+		if paymentUpdate.PaymentMethod != "" {
+			patchUpdate["data.payment_method"] = paymentUpdate.PaymentMethod
+		}
+		if paymentUpdate.Status != "" {
+			patchUpdate["data.status"] = paymentUpdate.Status
+		}
+	} else {
+		return fmt.Errorf("no valid fields for the patch request has been supplied for resource [%s]", id)
 	}
 
 	updateCall := bson.M{"$set": patchUpdate}

--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -3,11 +3,10 @@ package dao
 import (
 	"fmt"
 
-	"github.com/globalsign/mgo/bson"
-
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
 	"github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
 )
 
 var session *mgo.Session
@@ -67,6 +66,7 @@ func (m *Mongo) GetPaymentResource(id string) (*models.PaymentResource, error) {
 	return &resource, err
 }
 
+// PatchPaymentResource patches a payment resource from the DB
 func (m *Mongo) PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) error {
 	paymentSession, err := getMongoSession()
 	if err != nil {
@@ -87,7 +87,6 @@ func (m *Mongo) PatchPaymentResource(id string, paymentUpdate *models.PaymentRes
 	}
 
 	updateCall := bson.M{"$set": patchUpdate}
-	c.UpdateId(id, updateCall)
 
-	return nil
+	return c.UpdateId(id, updateCall)
 }

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -22,7 +22,7 @@ func Register(r *pat.Router, cfg config.Config) {
 	r.Get("/healthcheck", healthCheck).Name("get-healthcheck")
 	r.Post("/payments", p.CreatePaymentSession).Name("create-payment")
 	r.Get("/payments/{payment_id}", p.GetPaymentSession).Name("get-payment")
-	r.Patch("/private/payments/{payment_id}", service.CreateExternalPaymentJourney).Name("create-payment-journey")
+	r.Patch("/private/payments/{payment_id}", p.PatchPaymentSession).Name("patch-payment")
 }
 
 func healthCheck(w http.ResponseWriter, _ *http.Request) {

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -19,7 +19,7 @@ func TestUnitRegisterRoutes(t *testing.T) {
 		So(router.GetRoute("get-healthcheck"), ShouldNotBeNil)
 		So(router.GetRoute("create-payment"), ShouldNotBeNil)
 		So(router.GetRoute("get-payment"), ShouldNotBeNil)
-		So(router.GetRoute("create-payment-journey"), ShouldNotBeNil)
+		So(router.GetRoute("patch-payment"), ShouldNotBeNil)
 	})
 }
 

--- a/models/payment.go
+++ b/models/payment.go
@@ -24,7 +24,7 @@ type PaymentResourceData struct {
 	CreatedBy               CreatedBy      `json:"created_by"                          bson:"created_by"`
 	Description             string         `json:"description"                         bson:"description"`
 	Links                   Links          `json:"links"                               bson:"links"`
-	PaymentMethod           string         `json:"payment_method,omitempty"            bson:"payment_method,omitempty"`
+	PaymentMethod           string         `json:"payment_method"                      bson:"payment_method"`
 	RedirectURI             string         `json:"redirect_uri"                        bson:"redirect_uri"`
 	Reference               string         `json:"reference,omitempty"                 bson:"reference,omitempty"`
 	Status                  string         `json:"status"                              bson:"status"`

--- a/models/payment.go
+++ b/models/payment.go
@@ -25,7 +25,7 @@ type PaymentResourceData struct {
 	CreatedBy               CreatedBy      `json:"created_by"                          bson:"created_by"`
 	Description             string         `json:"description"                         bson:"description"`
 	Links                   Links          `json:"links"                               bson:"links"`
-	PaymentMethod           string         `json:"payment_method"                      bson:"payment_method"`
+	PaymentMethod           string         `json:"payment_method,omitempty"            bson:"payment_method"`
 	RedirectURI             string         `json:"redirect_uri"                        bson:"redirect_uri"`
 	Reference               string         `json:"reference,omitempty"                 bson:"reference,omitempty"`
 	Status                  string         `json:"status"                              bson:"status"`

--- a/service/payment.go
+++ b/service/payment.go
@@ -162,10 +162,16 @@ func (service *PaymentService) PatchPaymentSession(w http.ResponseWriter, req *h
 		return
 	}
 
-	err, httpStatus := service.DAO.PatchPaymentResource(id, &PaymentResourceUpdate)
+	if PaymentResourceUpdate.PaymentMethod == "" || PaymentResourceUpdate.Status == "" {
+		log.ErrorR(req, fmt.Errorf("no valid fields for the patch request has been supplied for resource [%s]", id))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	err = service.DAO.PatchPaymentResource(id, &PaymentResourceUpdate)
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error patching payment session on database: [%v]", err))
-		w.WriteHeader(httpStatus)
+		w.WriteHeader(http.StatusInternalServerError)
 	}
 }
 

--- a/service/payment.go
+++ b/service/payment.go
@@ -162,10 +162,10 @@ func (service *PaymentService) PatchPaymentSession(w http.ResponseWriter, req *h
 		return
 	}
 
-	err = service.DAO.PatchPaymentResource(id, &PaymentResourceUpdate)
+	err, httpStatus := service.DAO.PatchPaymentResource(id, &PaymentResourceUpdate)
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error patching payment session on database: [%v]", err))
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(httpStatus)
 	}
 }
 

--- a/service/payment.go
+++ b/service/payment.go
@@ -169,7 +169,7 @@ func (service *PaymentService) PatchPaymentSession(w http.ResponseWriter, req *h
 	}
 }
 
-func (service *PaymentService) getPaymentSession(id string) (*models.PaymentResource, int, error) {
+func (service *PaymentService) getPaymentSession(id string) (*models.PaymentResourceData, int, error) {
 	paymentResource, err := service.DAO.GetPaymentResource(id)
 	if paymentResource == nil {
 		return nil, http.StatusForbidden, fmt.Errorf("payment session not found. id: %s", id)
@@ -195,7 +195,7 @@ func (service *PaymentService) getPaymentSession(id string) (*models.PaymentReso
 
 	paymentResource.Data.Costs = *costs
 
-	return paymentResource, http.StatusOK, nil
+	return &paymentResource.Data, http.StatusOK, nil
 }
 
 func getTotalAmount(costs *[]models.CostResource) (string, error) {

--- a/service/payment.go
+++ b/service/payment.go
@@ -162,7 +162,7 @@ func (service *PaymentService) PatchPaymentSession(w http.ResponseWriter, req *h
 		return
 	}
 
-	if PaymentResourceUpdate.PaymentMethod == "" || PaymentResourceUpdate.Status == "" {
+	if PaymentResourceUpdate.PaymentMethod == "" && PaymentResourceUpdate.Status == "" {
 		log.ErrorR(req, fmt.Errorf("no valid fields for the patch request has been supplied for resource [%s]", id))
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -404,7 +404,7 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
-		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(fmt.Errorf("error"))
+		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(fmt.Errorf("error"), http.StatusInternalServerError)
 
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)
@@ -425,7 +425,7 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
-		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(nil)
+		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(nil, http.StatusOK)
 
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -404,7 +404,7 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
-		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(fmt.Errorf("error"), http.StatusInternalServerError)
+		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(fmt.Errorf("error"))
 
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)
@@ -425,7 +425,7 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
-		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(nil, http.StatusOK)
+		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(nil)
 
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)


### PR DESCRIPTION
- Added a new Patch Request which can update only the payment_method and status fields. 
- Refactored the GetPayment and GetCosts functions so they can be called from internal function ready for later POST request functionality for external pay session.

Resolves: CPS-208

### Type of change

* [ ] Bug fix
* [X] New feature
* [ ] Breaking change

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)