### PR TITLE
Add enumeration for payment methods and format created_at date correctly

### DIFF
--- a/models/payment.go
+++ b/models/payment.go
@@ -26,7 +26,6 @@ type PaymentResourceData struct {
 	Description             string         `json:"description"                         bson:"description"`
 	Links                   Links          `json:"links"                               bson:"links"`
 	PaymentMethod           string         `json:"payment_method,omitempty"            bson:"payment_method"`
-	RedirectURI             string         `json:"redirect_uri"                        bson:"redirect_uri"`
 	Reference               string         `json:"reference,omitempty"                 bson:"reference,omitempty"`
 	Status                  string         `json:"status"                              bson:"status"`
 	Costs                   []CostResource `json:"items"`


### PR DESCRIPTION
2 small fixes for errors reported in the api spec tests:

1 - The payment status was not populated. This pull request adds an enum of possible states (we only need pending for now, but all these states will be needed soon) and sets the payment status to pending when creating a PaymentResource

2 - The format of the date generated by golang using time.Now() doesn't match the format specified in the API design spec. In order to get the correct date format, I had to format time.now() which generated a string, then parse the result to match the spec format.

CPS-223

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__