### PR TITLE
Add enumeration for payment methods and format created_at date correctly

### DIFF
--- a/models/payment.go
+++ b/models/payment.go
@@ -26,7 +26,6 @@ type PaymentResourceData struct {
 	Description             string         `json:"description"                         bson:"description"`
 	Links                   Links          `json:"links"                               bson:"links"`
 	PaymentMethod           string         `json:"payment_method,omitempty"            bson:"payment_method"`
-	RedirectURI             string         `json:"redirect_uri"                        bson:"redirect_uri"`
 	Reference               string         `json:"reference,omitempty"                 bson:"reference,omitempty"`
 	Status                  string         `json:"status"                              bson:"status"`
 	Costs                   []CostResource `json:"items"`

--- a/service/payment.go
+++ b/service/payment.go
@@ -30,7 +30,7 @@ type PaymentStatus int
 
 // Enumeration containing all possible payment statuses
 const (
-	Pending PaymentStatus = 1 + iota
+	PaymentPending PaymentStatus = 1 + iota
 	InProgress
 	Paid
 	NoFunds
@@ -39,8 +39,8 @@ const (
 
 // String representation of payment statuses
 var paymentStatuses = [...]string{
-	"pending",
-	"in-rogress",
+	"payment-pending",
+	"in-progress",
 	"paid",
 	"no-funds ",
 	"failed",
@@ -116,7 +116,7 @@ func (service *PaymentService) CreatePaymentSession(w http.ResponseWriter, req *
 	}
 
 	paymentResource.Data.Reference = incomingPaymentResourceRequest.Reference
-	paymentResource.Data.Status = Pending.String()
+	paymentResource.Data.Status = PaymentPending.String()
 	paymentResource.ID = generateID()
 
 	journeyURL := service.Config.PaymentsWebURL + "/payments/" + paymentResource.ID + "/pay"

--- a/service/payment.go
+++ b/service/payment.go
@@ -111,11 +111,6 @@ func (service *PaymentService) CreatePaymentSession(w http.ResponseWriter, req *
 	paymentResource.Data.Amount = totalAmount
 	// To match the format time is saved to mongo, e.g. "2018-11-22T08:39:16.782Z", truncate the time
 	paymentResource.Data.CreatedAt = time.Now().Truncate(time.Millisecond)
-	if err != nil {
-		log.ErrorR(req, fmt.Errorf("error parsing date: %v", err))
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
 
 	paymentResource.Data.Reference = incomingPaymentResourceRequest.Reference
 	paymentResource.Data.Status = Pending.String()

--- a/service/payment.go
+++ b/service/payment.go
@@ -30,7 +30,7 @@ type PaymentStatus int
 
 // Enumeration containing all possible payment statuses
 const (
-	PaymentPending PaymentStatus = 1 + iota
+	Pending PaymentStatus = 1 + iota
 	InProgress
 	Paid
 	NoFunds
@@ -39,7 +39,7 @@ const (
 
 // String representation of payment statuses
 var paymentStatuses = [...]string{
-	"payment-pending",
+	"pending",
 	"in-progress",
 	"paid",
 	"no-funds ",
@@ -107,8 +107,8 @@ func (service *PaymentService) CreatePaymentSession(w http.ResponseWriter, req *
 		Surname:  surname,
 	}
 	paymentResource.Data.Amount = totalAmount
-	// To get the correct time format, format the current time and parse the result
-	paymentResource.Data.CreatedAt, err = time.Parse("2006-01-02 15:04:05.000", time.Now().Format("2006-01-02 15:04:05.000"))
+	// To match the format time is saved to mongo, e.g. "2018-11-22T08:39:16.782Z", truncate the time
+	paymentResource.Data.CreatedAt = time.Now().Truncate(time.Millisecond)
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error parsing date: %v", err))
 		w.WriteHeader(http.StatusInternalServerError)
@@ -116,7 +116,7 @@ func (service *PaymentService) CreatePaymentSession(w http.ResponseWriter, req *
 	}
 
 	paymentResource.Data.Reference = incomingPaymentResourceRequest.Reference
-	paymentResource.Data.Status = PaymentPending.String()
+	paymentResource.Data.Status = Pending.String()
 	paymentResource.ID = generateID()
 
 	journeyURL := service.Config.PaymentsWebURL + "/payments/" + paymentResource.ID + "/pay"

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -169,11 +169,18 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		if err := json.Unmarshal(responseByteArray, &createdPaymentResource); err != nil {
 			panic(err)
 		}
+
 		So(createdPaymentResource.Links.Journey, ShouldNotBeEmpty)
-		re := regexp.MustCompile("https://payments.companieshouse.gov.uk/payments/(.*)/pay")
-		So(re.MatchString(createdPaymentResource.Links.Journey), ShouldEqual, true)
-		So(re.MatchString(w.Header().Get("Location")), ShouldEqual, true)
+		// Regex format for journey url
+		regJourney := regexp.MustCompile("https://payments.companieshouse.gov.uk/payments/(.*)/pay")
+		So(regJourney.MatchString(createdPaymentResource.Links.Journey), ShouldEqual, true)
+		So(regJourney.MatchString(w.Header().Get("Location")), ShouldEqual, true)
+		So(createdPaymentResource.Status, ShouldEqual, PaymentPending.String())
 		So(createdPaymentResource.CreatedBy, ShouldNotBeEmpty)
+		// Regex format for self url
+		regSelf := regexp.MustCompile("payments/(.*)")
+		So(regSelf.MatchString(createdPaymentResource.Links.Self), ShouldEqual, true)
+
 	})
 
 	Convey("Valid request - multiple costs", t, func() {
@@ -201,11 +208,15 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		}
 
 		So(createdPaymentResource.Links.Journey, ShouldNotBeEmpty)
-		re := regexp.MustCompile("https://payments.companieshouse.gov.uk/payments/(.*)/pay")
-		So(re.MatchString(createdPaymentResource.Links.Journey), ShouldEqual, true)
-		So(re.MatchString(w.Header().Get("Location")), ShouldEqual, true)
-
+		// Regex format for journey url
+		regJourney := regexp.MustCompile("https://payments.companieshouse.gov.uk/payments/(.*)/pay")
+		So(regJourney.MatchString(createdPaymentResource.Links.Journey), ShouldEqual, true)
+		So(regJourney.MatchString(w.Header().Get("Location")), ShouldEqual, true)
+		So(createdPaymentResource.Status, ShouldEqual, PaymentPending.String())
 		So(createdPaymentResource.CreatedBy, ShouldNotBeEmpty)
+		// Regex format for self url
+		regSelf := regexp.MustCompile("payments/(.*)")
+		So(regSelf.MatchString(createdPaymentResource.Links.Self), ShouldEqual, true)
 	})
 
 	Convey("Valid generated PaymentResource ID", t, func() {

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -175,7 +175,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		regJourney := regexp.MustCompile("https://payments.companieshouse.gov.uk/payments/(.*)/pay")
 		So(regJourney.MatchString(createdPaymentResource.Links.Journey), ShouldEqual, true)
 		So(regJourney.MatchString(w.Header().Get("Location")), ShouldEqual, true)
-		So(createdPaymentResource.Status, ShouldEqual, PaymentPending.String())
+		So(createdPaymentResource.Status, ShouldEqual, Pending.String())
 		So(createdPaymentResource.CreatedBy, ShouldNotBeEmpty)
 		// Regex format for self url
 		regSelf := regexp.MustCompile("payments/(.*)")
@@ -212,7 +212,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		regJourney := regexp.MustCompile("https://payments.companieshouse.gov.uk/payments/(.*)/pay")
 		So(regJourney.MatchString(createdPaymentResource.Links.Journey), ShouldEqual, true)
 		So(regJourney.MatchString(w.Header().Get("Location")), ShouldEqual, true)
-		So(createdPaymentResource.Status, ShouldEqual, PaymentPending.String())
+		So(createdPaymentResource.Status, ShouldEqual, Pending.String())
 		So(createdPaymentResource.CreatedBy, ShouldNotBeEmpty)
 		// Regex format for self url
 		regSelf := regexp.MustCompile("payments/(.*)")


### PR DESCRIPTION
3 small fixes for errors reported in the api spec tests:

1 - The payment status was not populated. This pull request adds an enum of possible states (we only need pending for now, but all these states will be needed soon) and sets the payment status to pending when creating a PaymentResource

2 - The format of the date generated by golang using time.Now() doesn't match the format specified in the API design spec and stored in mongo. In order to get the correct date format, I trim the time to produce only 3 decimal places.

3 - Remove the redirect_uri from the model to adhere to the spec

CPS-223

All payment API spec tests now pass with no failures.

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [ x] I have added unit tests for new code that I have added
* [x ] I have added/updated functional tests where appropriate
* [ x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__