### PR TITLE
Add GET request for GovPay status check

### DIFF
--- a/models/payment.go
+++ b/models/payment.go
@@ -12,9 +12,9 @@ type IncomingPaymentResourceRequest struct {
 
 // PaymentResource contains all payment details to be stored in the DB
 type PaymentResource struct {
-	ID               string              `json:"_id"   bson:"_id"`
-	PaymentStatusURI string              `json:"payment_status_url"   bson:"payment_status_url"`
-	Data             PaymentResourceData `json:"data"  bson:"data"`
+	ID               string              `json:"_id"                  bson:"_id"`
+	PaymentStatusURL string              `json:"payment_status_url"   bson:"payment_status_url"`
+	Data             PaymentResourceData `json:"data"                 bson:"data"`
 }
 
 // PaymentResourceData is public facing payment details to be returned in the response

--- a/models/payment.go
+++ b/models/payment.go
@@ -12,8 +12,9 @@ type IncomingPaymentResourceRequest struct {
 
 // PaymentResource contains all payment details to be stored in the DB
 type PaymentResource struct {
-	ID   string              `json:"_id"   bson:"_id"`
-	Data PaymentResourceData `json:"data"  bson:"data"`
+	ID               string              `json:"_id"   bson:"_id"`
+	PaymentStatusURI string              `json:"payment_status_url"   bson:"payment_status_url"`
+	Data             PaymentResourceData `json:"data"  bson:"data"`
 }
 
 // PaymentResourceData is public facing payment details to be returned in the response

--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -60,3 +60,36 @@ func returnNextURLGovPay(paymentResourceData *models.PaymentResourceData, id str
 
 	return govPayResponse.GovPayLinks.NextURL.HREF, nil
 }
+
+// To get the status of a GovPay payment, GET the payment resource from GovPay and return the State block
+func getGovPayPaymentState(paymentResource *models.PaymentResource, cfg *config.Config) (*models.State, error) {
+	request, err := http.NewRequest("GET", paymentResource.PaymentStatusURI, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error generating request for GovPay: [%s]", err)
+	}
+
+	request.Header.Add("accept", "application/json")
+	request.Header.Add("authorization", "Bearer "+cfg.GovPayBearerToken)
+	request.Header.Add("content-type", "application/json")
+
+	// Make call to GovPay to check state of payment
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("error sending request to GovPay to check payment status: [%s]", err)
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response from GovPay when checking payment status: [%s]", err)
+	}
+
+	govPayResponse := &models.IncomingGovPayResponse{}
+	err = json.Unmarshal(body, govPayResponse)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response from GovPay when checking payment status: [%s]", err)
+	}
+
+	// Return the status of the payment
+	return &govPayResponse.State, nil
+}

--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -63,7 +63,7 @@ func returnNextURLGovPay(paymentResourceData *models.PaymentResourceData, id str
 
 // To get the status of a GovPay payment, GET the payment resource from GovPay and return the State block
 func getGovPayPaymentState(paymentResource *models.PaymentResource, cfg *config.Config) (*models.State, error) {
-	request, err := http.NewRequest("GET", paymentResource.PaymentStatusURI, nil)
+	request, err := http.NewRequest("GET", paymentResource.PaymentStatusURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error generating request for GovPay: [%s]", err)
 	}

--- a/service/gov_pay_test.go
+++ b/service/gov_pay_test.go
@@ -95,9 +95,9 @@ func TestUnitGovPay(t *testing.T) {
 		IncomingGovPayResponse := models.IncomingGovPayResponse{State: GovPayState}
 
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, IncomingGovPayResponse)
-		httpmock.RegisterResponder("GET", cfg.GovPayURL, jsonResponse)
+		httpmock.RegisterResponder("GET", "testurl", jsonResponse)
 
-		paymentResource := models.PaymentResource{}
+		paymentResource := models.PaymentResource{PaymentStatusURL: "testurl"}
 		govPayResponse, err := getGovPayPaymentState(&paymentResource, cfg)
 
 		So(govPayResponse, ShouldResemble, &GovPayState)

--- a/service/gov_pay_test.go
+++ b/service/gov_pay_test.go
@@ -88,4 +88,20 @@ func TestUnitGovPay(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 
+	Convey("Valid GET request to GovPay and return status", t, func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		GovPayState := models.State{Status: "complete", Finished: true}
+		IncomingGovPayResponse := models.IncomingGovPayResponse{State: GovPayState}
+
+		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, IncomingGovPayResponse)
+		httpmock.RegisterResponder("GET", cfg.GovPayURL, jsonResponse)
+
+		paymentResource := models.PaymentResource{}
+		govPayResponse, err := getGovPayPaymentState(&paymentResource, cfg)
+
+		So(govPayResponse, ShouldResemble, &GovPayState)
+		So(err, ShouldBeNil)
+	})
+
 }


### PR DESCRIPTION
This PR adds a function that issues a GET request to GovPay to check the status of a GovPay payment. It does this by using the PaymentStatusURI that is stored when creating the GovPay session in the web. The function take s payment resource, uses the PaymentStatusURI in the metadata and makes the GET request, then returns the state of the payment.

CPS-146

### Type of change

* [ ] Bug fix
* [x ] New feature
* [ ] Breaking change

### Pull request checklist

* [x ] I have added unit tests for new code that I have added
* [x ] I have added/updated functional tests where appropriate
* [ x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__