### PR TITLE
Save the Payment_Status_Url returned from GovPay

### DIFF
--- a/dao/dao.go
+++ b/dao/dao.go
@@ -6,5 +6,5 @@ import "github.com/companieshouse/payments.api.ch.gov.uk/models"
 type DAO interface {
 	CreatePaymentResource(paymentResource *models.PaymentResource) error
 	GetPaymentResource(string) (*models.PaymentResource, error)
-	PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) error
+	PatchPaymentResource(id string, paymentUpdate *models.PaymentResource) error
 }

--- a/dao/mock_dao.go
+++ b/dao/mock_dao.go
@@ -59,7 +59,7 @@ func (mr *MockDAOMockRecorder) GetPaymentResource(arg0 interface{}) *gomock.Call
 }
 
 // PatchPaymentResource mocks base method
-func (m *MockDAO) PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) error {
+func (m *MockDAO) PatchPaymentResource(id string, paymentUpdate *models.PaymentResource) error {
 	ret := m.ctrl.Call(m, "PatchPaymentResource", id, paymentUpdate)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -76,7 +76,7 @@ func (m *Mongo) GetPaymentResource(id string) (*models.PaymentResource, error) {
 }
 
 // PatchPaymentResource patches a payment resource from the DB
-func (m *Mongo) PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceData) error {
+func (m *Mongo) PatchPaymentResource(id string, paymentUpdate *models.PaymentResource) error {
 	paymentSession, err := getMongoSession()
 	if err != nil {
 		return err
@@ -92,11 +92,14 @@ func (m *Mongo) PatchPaymentResource(id string, paymentUpdate *models.PaymentRes
 	patchUpdate := make(bson.M)
 
 	// Patch only these fields
-	if paymentUpdate.PaymentMethod != "" {
-		patchUpdate["data.payment_method"] = paymentUpdate.PaymentMethod
+	if paymentUpdate.Data.PaymentMethod != "" {
+		patchUpdate["data.payment_method"] = paymentUpdate.Data.PaymentMethod
 	}
-	if paymentUpdate.Status != "" {
-		patchUpdate["data.status"] = paymentUpdate.Status
+	if paymentUpdate.Data.Status != "" {
+		patchUpdate["data.status"] = paymentUpdate.Data.Status
+	}
+	if paymentUpdate.PaymentStatusURL != "" {
+		patchUpdate["payment_status_url"] = paymentUpdate.PaymentStatusURL
 	}
 
 	updateCall := bson.M{"$set": patchUpdate}

--- a/models/payment.go
+++ b/models/payment.go
@@ -12,8 +12,9 @@ type IncomingPaymentResourceRequest struct {
 
 // PaymentResource contains all payment details to be stored in the DB
 type PaymentResource struct {
-	ID   string              `json:"_id"   bson:"_id"`
-	Data PaymentResourceData `json:"data"  bson:"data"`
+	ID               string              `json:"_id"                bson:"_id"`
+	PaymentStatusURL string              `json:"payment_status_url" bson:"payment_status_url"`
+	Data             PaymentResourceData `json:"data"               bson:"data"`
 }
 
 // PaymentResourceData is public facing payment details to be returned in the response

--- a/service/external_paysession.go
+++ b/service/external_paysession.go
@@ -31,7 +31,7 @@ func (service *PaymentService) CreateExternalPaymentJourney(w http.ResponseWrite
 
 	switch paymentSession.PaymentMethod {
 	case "GovPay":
-		paymentJourney.NextURL, err = returnNextURLGovPay(paymentSession, id, &service.Config)
+		paymentJourney.NextURL, err = service.returnNextURLGovPay(paymentSession, id, &service.Config)
 		if err != nil {
 			log.ErrorR(req, fmt.Errorf("error communicating with GovPay: [%s]", err))
 			w.WriteHeader(http.StatusInternalServerError)

--- a/service/external_paysession_test.go
+++ b/service/external_paysession_test.go
@@ -138,6 +138,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
 		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResource{ID: "1234", Data: models.PaymentResourceData{Amount: "10.00", Links: models.Links{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay"}}, nil)
+		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(nil)
 
 		req, err := http.NewRequest("Get", "", nil)
 		So(err, ShouldBeNil)
@@ -155,7 +156,9 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
 
 		NextURL := models.NextURL{HREF: "nextURL"}
-		GovPayLinks := models.GovPayLinks{NextURL: NextURL}
+		Self := models.Self{HREF: "paymentStatusURL"}
+
+		GovPayLinks := models.GovPayLinks{NextURL: NextURL, Self: Self}
 
 		IncomingGovPayResponse := models.IncomingGovPayResponse{GovPayLinks: GovPayLinks}
 		govPayJSONResponse, _ := httpmock.NewJsonResponder(http.StatusCreated, IncomingGovPayResponse)

--- a/service/gov_pay_test.go
+++ b/service/gov_pay_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
+
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
 	"github.com/golang/mock/gomock"
@@ -18,30 +20,39 @@ func TestUnitGovPay(t *testing.T) {
 	cfg, _ := config.Get()
 
 	Convey("Error converting amount to pay to pence", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, httpmock.NewErrorResponder(fmt.Errorf("error")))
 
 		paymentResourceData := models.PaymentResourceData{Amount: "250.567"}
-		govPayResponse, err := returnNextURLGovPay(&paymentResourceData, "1234", cfg)
+		govPayResponse, err := mockPaymentService.returnNextURLGovPay(&paymentResourceData, "1234", cfg)
 
 		So(govPayResponse, ShouldEqual, "")
 		So(err, ShouldNotBeNil)
 	})
 
 	Convey("Error sending request to GovPay", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, httpmock.NewErrorResponder(fmt.Errorf("error")))
 
 		paymentResourceData := models.PaymentResourceData{Amount: "250"}
-		govPayResponse, err := returnNextURLGovPay(&paymentResourceData, "1234", cfg)
+		govPayResponse, err := mockPaymentService.returnNextURLGovPay(&paymentResourceData, "1234", cfg)
 
 		So(govPayResponse, ShouldEqual, "")
 		So(err, ShouldNotBeNil)
 	})
 
 	Convey("Error reading response from GovPay", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 
@@ -49,13 +60,16 @@ func TestUnitGovPay(t *testing.T) {
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, jsonResponse)
 
 		paymentResourceData := models.PaymentResourceData{Amount: "250"}
-		govPayResponse, err := returnNextURLGovPay(&paymentResourceData, "1234", cfg)
+		govPayResponse, err := mockPaymentService.returnNextURLGovPay(&paymentResourceData, "1234", cfg)
 
 		So(govPayResponse, ShouldEqual, "")
 		So(err, ShouldNotBeNil)
 	})
 
 	Convey("Status code not 201", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		IncomingGovPayResponse := models.IncomingGovPayResponse{}
@@ -64,25 +78,32 @@ func TestUnitGovPay(t *testing.T) {
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, jsonResponse)
 
 		paymentResourceData := models.PaymentResourceData{Amount: "250"}
-		govPayResponse, err := returnNextURLGovPay(&paymentResourceData, "1234", cfg)
+		govPayResponse, err := mockPaymentService.returnNextURLGovPay(&paymentResourceData, "1234", cfg)
 
 		So(govPayResponse, ShouldEqual, "")
 		So(err, ShouldNotBeNil)
 	})
 
 	Convey("Valid request to GovPay and returned NextURL", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+
+		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(nil)
+
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		journeyURL := "nextUrl"
 		NextURL := models.NextURL{HREF: journeyURL}
-		GovPayLinks := models.GovPayLinks{NextURL: NextURL}
+		Self := models.Self{HREF: "paymentStatusURL"}
+
+		GovPayLinks := models.GovPayLinks{NextURL: NextURL, Self: Self}
 		IncomingGovPayResponse := models.IncomingGovPayResponse{GovPayLinks: GovPayLinks}
 
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusCreated, IncomingGovPayResponse)
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, jsonResponse)
 
 		paymentResourceData := models.PaymentResourceData{Amount: "250"}
-		govPayResponse, err := returnNextURLGovPay(&paymentResourceData, "1234", cfg)
+		govPayResponse, err := mockPaymentService.returnNextURLGovPay(&paymentResourceData, "1234", cfg)
 
 		So(govPayResponse, ShouldEqual, journeyURL)
 		So(err, ShouldBeNil)

--- a/service/payment.go
+++ b/service/payment.go
@@ -187,33 +187,42 @@ func (service *PaymentService) PatchPaymentSession(w http.ResponseWriter, req *h
 	}
 
 	requestDecoder := json.NewDecoder(req.Body)
-	var PaymentResourceUpdate models.PaymentResourceData
-	err := requestDecoder.Decode(&PaymentResourceUpdate)
+	var PaymentResourceUpdateData models.PaymentResourceData
+	err := requestDecoder.Decode(&PaymentResourceUpdateData)
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("request body invalid: [%v]", err))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	if PaymentResourceUpdate.PaymentMethod == "" && PaymentResourceUpdate.Status == "" {
-		log.ErrorR(req, fmt.Errorf("no valid fields for the patch request has been supplied for resource [%s]", id))
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
+	var PaymentResourceUpdate models.PaymentResource
+	PaymentResourceUpdate.Data = PaymentResourceUpdateData
 
-	err = service.DAO.PatchPaymentResource(id, &PaymentResourceUpdate)
+	httpStatus, err := service.patchPaymentSession(id, PaymentResourceUpdate)
 	if err != nil {
-		if err.Error() == "not found" {
-			log.ErrorR(req, fmt.Errorf("could not find payment resource to patch"))
-			w.WriteHeader(http.StatusForbidden)
-			return
-		}
-		log.ErrorR(req, fmt.Errorf("error patching payment session on database: [%v]", err))
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(httpStatus)
+		log.ErrorR(req, err)
 		return
 	}
 
 	log.InfoR(req, "Successful PATCH request for payment resource", log.Data{"payment_id": id, "status": http.StatusOK})
+}
+
+func (service *PaymentService) patchPaymentSession(id string, PaymentResourceUpdate models.PaymentResource) (int, error) {
+
+	if PaymentResourceUpdate.Data.PaymentMethod == "" && PaymentResourceUpdate.Data.Status == "" && PaymentResourceUpdate.PaymentStatusURL == "" {
+		return http.StatusBadRequest, fmt.Errorf("no valid fields for the patch request has been supplied for resource [%s]", id)
+	}
+
+	err := service.DAO.PatchPaymentResource(id, &PaymentResourceUpdate)
+	if err != nil {
+		if err.Error() == "not found" {
+			return http.StatusForbidden, fmt.Errorf("could not find payment resource to patch")
+		}
+		return http.StatusInternalServerError, fmt.Errorf("error patching payment session on database: [%v]", err)
+	}
+
+	return http.StatusOK, nil
 }
 
 func (service *PaymentService) getPaymentSession(id string) (*models.PaymentResourceData, int, error) {


### PR DESCRIPTION
The payment_status_url returned from GovPay to be saved into Mongo. 
This requires updating the current patch method to also handle patching metadata. 

Resolves CPS-144

* [X] New feature

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__