### PR TITLE
Fix for Router dependency breaking change

### DIFF
--- a/handlers/register.go
+++ b/handlers/register.go
@@ -7,11 +7,11 @@ import (
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
 	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
 	"github.com/companieshouse/payments.api.ch.gov.uk/service"
-	"github.com/gorilla/pat"
+	"github.com/gorilla/mux"
 )
 
 // Register defines the route mappings
-func Register(r *pat.Router, cfg config.Config) {
+func Register(r *mux.Router, cfg config.Config) {
 	m := &dao.Mongo{
 		URL: cfg.MongoDBURL,
 	}
@@ -20,11 +20,11 @@ func Register(r *pat.Router, cfg config.Config) {
 		Config: cfg,
 	}
 
-	r.Get("/healthcheck", healthCheck).Name("get-healthcheck")
-	r.Post("/payments", p.CreatePaymentSession).Name("create-payment")
-	r.Get("/payments/{payment_id}", p.GetPaymentSession).Name("get-payment")
-	r.Patch("/private/payments/{payment_id}", p.PatchPaymentSession).Name("patch-payment")
-	r.Post("/private/payments/{payment_id}/external-journey", p.CreateExternalPaymentJourney).Name("create-external-payment-journey")
+	r.HandleFunc("/healthcheck", healthCheck).Methods("GET").Name("get-healthcheck")
+	r.HandleFunc("/payments", p.CreatePaymentSession).Methods("POST").Name("create-payment")
+	r.HandleFunc("/payments/{payment_id}", p.GetPaymentSession).Methods("GET").Name("get-payment")
+	r.HandleFunc("/private/payments/{payment_id}", p.PatchPaymentSession).Methods("PATCH").Name("patch-payment")
+	r.HandleFunc("/private/payments/{payment_id}/external-journey", p.CreateExternalPaymentJourney).Methods("POST").Name("create-external-payment-journey")
 }
 
 func healthCheck(w http.ResponseWriter, _ *http.Request) {

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
-	"github.com/gorilla/pat"
+	"github.com/gorilla/mux"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestUnitRegisterRoutes(t *testing.T) {
 	Convey("Register routes", t, func() {
-		router := pat.New()
+		router := mux.NewRouter()
 		cfg, _ := config.Get()
 		Register(router, *cfg)
 		So(router.GetRoute("get-healthcheck"), ShouldNotBeNil)

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 
 	eric "github.com/companieshouse/eric/chain" // Identity bridge
 
-	"github.com/gorilla/pat"
+	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
 )
 
@@ -25,7 +25,7 @@ func main() {
 		return
 	}
 
-	router := pat.New()
+	router := mux.NewRouter()
 	chain := alice.New()
 
 	chain = eric.Register(chain)

--- a/service/external_paysession.go
+++ b/service/external_paysession.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
+	"github.com/gorilla/mux"
 )
 
 // CreateExternalPaymentJourney creates an external payment session with a Payment Provider that is given, e.g: GovPay
 func (service *PaymentService) CreateExternalPaymentJourney(w http.ResponseWriter, req *http.Request) {
-	id := req.URL.Query().Get(":payment_id")
+	vars := mux.Vars(req)
+	id := vars["payment_id"]
 	if id == "" {
 		log.ErrorR(req, fmt.Errorf("payment id not supplied"))
 		w.WriteHeader(http.StatusBadRequest)

--- a/service/external_paysession_test.go
+++ b/service/external_paysession_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
 	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"

--- a/service/external_paysession_test.go
+++ b/service/external_paysession_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gorilla/mux"
+
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
 	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
@@ -35,12 +37,10 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 
 		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResource{}, fmt.Errorf("error"))
 
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 
 		w := httptest.NewRecorder()
 		mockPaymentService.CreateExternalPaymentJourney(w, req)
@@ -56,12 +56,10 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 
 		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResource{ID: "1234", Data: models.PaymentResourceData{Amount: "10.00", Links: models.Links{Resource: "http://dummy-resource"}, PaymentMethod: "PayPal"}}, nil)
 
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 
 		w := httptest.NewRecorder()
 
@@ -81,12 +79,10 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 
 		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResource{ID: "1234", Data: models.PaymentResourceData{Amount: "10.00", Links: models.Links{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay"}}, nil)
 
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 
 		w := httptest.NewRecorder()
 
@@ -108,12 +104,10 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 
 		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResource{ID: "1234", Data: models.PaymentResourceData{Amount: "10.00", Links: models.Links{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay"}}, nil)
 
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 
 		w := httptest.NewRecorder()
 
@@ -139,12 +133,10 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 
 		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResource{ID: "1234", Data: models.PaymentResourceData{Amount: "10.00", Links: models.Links{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay"}}, nil)
 
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 
 		w := httptest.NewRecorder()
 

--- a/service/payment.go
+++ b/service/payment.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gorilla/mux"
+
 	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
 	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
@@ -146,7 +148,8 @@ func (service *PaymentService) CreatePaymentSession(w http.ResponseWriter, req *
 
 // GetPaymentSession retrieves the payment session
 func (service *PaymentService) GetPaymentSession(w http.ResponseWriter, req *http.Request) {
-	id := req.URL.Query().Get(":payment_id")
+	vars := mux.Vars(req)
+	id := vars["payment_id"]
 	if id == "" {
 		log.ErrorR(req, fmt.Errorf("payment id not supplied"))
 		w.WriteHeader(http.StatusBadRequest)
@@ -173,7 +176,8 @@ func (service *PaymentService) GetPaymentSession(w http.ResponseWriter, req *htt
 
 // PatchPaymentSession patches and updates the payment session
 func (service *PaymentService) PatchPaymentSession(w http.ResponseWriter, req *http.Request) {
-	id := req.URL.Query().Get(":payment_id")
+	vars := mux.Vars(req)
+	id := vars["payment_id"]
 	if id == "" {
 		log.ErrorR(req, fmt.Errorf("payment id not supplied"))
 		w.WriteHeader(http.StatusBadRequest)

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
 	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/jarcoal/httpmock.v1"
 )
@@ -24,7 +25,7 @@ var defaultCost = models.CostResource{
 	ClassOfPayment:          []string{"class"},
 	Description:             "desc",
 	DescriptionIdentifier:   "identifier",
-	Links:                   models.Links{Self: "self"},
+	Links: models.Links{Self: "self"},
 }
 
 var defaultCostArray = []models.CostResource{
@@ -162,7 +163,9 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		mockPaymentService := createMockPaymentService(mock, cfg)
 		mock.EXPECT().CreatePaymentResource(gomock.Any())
 
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
 
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
@@ -259,10 +262,9 @@ func TestUnitGetPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 		mock.EXPECT().GetPaymentResource("invalid").Return(nil, nil)
-		req, err := http.NewRequest("Get", "", nil)
-		q := req.URL.Query()
-		q.Add(":payment_id", "invalid")
-		req.URL.RawQuery = q.Encode()
+		path := fmt.Sprintf("/payments/%s", "invalid")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "invalid"})
 		So(err, ShouldBeNil)
 		w := httptest.NewRecorder()
 		mockPaymentService.GetPaymentSession(w, req)
@@ -273,11 +275,10 @@ func TestUnitGetPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResource{}, fmt.Errorf("error"))
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 		w := httptest.NewRecorder()
 		mockPaymentService.GetPaymentSession(w, req)
 		So(w.Code, ShouldEqual, 500)
@@ -287,11 +288,10 @@ func TestUnitGetPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResource{}, nil)
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 		w := httptest.NewRecorder()
 		mockPaymentService.GetPaymentSession(w, req)
 		So(w.Code, ShouldEqual, 400)
@@ -304,12 +304,11 @@ func TestUnitGetPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResource{ID: "1234", Data: models.PaymentResourceData{Amount: "x", Links: models.Links{Resource: "http://dummy-resource"}}}, nil)
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
@@ -327,12 +326,11 @@ func TestUnitGetPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResource{ID: "1234", Data: models.PaymentResourceData{Amount: "100", Links: models.Links{Resource: "http://dummy-resource"}}}, nil)
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 		w := httptest.NewRecorder()
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
@@ -348,12 +346,11 @@ func TestUnitGetPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResource{ID: "1234", Data: models.PaymentResourceData{Amount: "10.00", Links: models.Links{Resource: "http://dummy-resource"}}}, nil)
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 		w := httptest.NewRecorder()
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
@@ -368,12 +365,11 @@ func TestUnitGetPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResource{ID: "1234", Data: models.PaymentResourceData{Amount: "20.00", Links: models.Links{Resource: "http://dummy-resource"}}}, nil)
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 		w := httptest.NewRecorder()
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
@@ -403,11 +399,11 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 
 	Convey("Empty Request Body", t, func() {
 		mockPaymentService := createMockPaymentService(dao.NewMockDAO(mockCtrl), cfg)
-		req, err := http.NewRequest("GET", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
+
 		w := httptest.NewRecorder()
 		mockPaymentService.PatchPaymentSession(w, req)
 		So(w.Code, ShouldEqual, 400)
@@ -415,11 +411,10 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 
 	Convey("Invalid Request Body", t, func() {
 		mockPaymentService := createMockPaymentService(dao.NewMockDAO(mockCtrl), cfg)
-		req, err := http.NewRequest("GET", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 		req.Body = ioutil.NopCloser(bytes.NewReader([]byte("invalid_body")))
 		w := httptest.NewRecorder()
 		mockPaymentService.PatchPaymentSession(w, req)
@@ -432,12 +427,10 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 
 		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(fmt.Errorf("error"))
 
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBodyPatch))
 		req.Header.Set("Eric-Authorised-User", "test@companieshouse.gov.uk; forename=f; surname=s")
@@ -451,12 +444,10 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBodyPatchInvalid))
 		req.Header.Set("Eric-Authorised-User", "test@companieshouse.gov.uk; forename=f; surname=s")
@@ -472,12 +463,10 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 
 		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(fmt.Errorf("not found"))
 
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBodyPatch))
 		req.Header.Set("Eric-Authorised-User", "test@companieshouse.gov.uk; forename=f; surname=s")
@@ -493,12 +482,10 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 
 		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(nil)
 
-		req, err := http.NewRequest("Get", "", nil)
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
 		So(err, ShouldBeNil)
-
-		q := req.URL.Query()
-		q.Add(":payment_id", "1234")
-		req.URL.RawQuery = q.Encode()
 
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBodyPatch))
 		req.Header.Set("Eric-Authorised-User", "test@companieshouse.gov.uk; forename=f; surname=s")
@@ -551,7 +538,7 @@ func TestUnitValidateCosts(t *testing.T) {
 			ClassOfPayment:          []string{"class"},
 			Description:             "",
 			DescriptionIdentifier:   "identifier",
-			Links:                   models.Links{Self: "self"},
+			Links: models.Links{Self: "self"},
 		}}
 		So(validateCosts(&cost), ShouldNotBeNil)
 	})
@@ -562,7 +549,7 @@ func TestUnitValidateCosts(t *testing.T) {
 			ClassOfPayment:          []string{"class"},
 			Description:             "desc",
 			DescriptionIdentifier:   "identifier",
-			Links:                   models.Links{Self: "self"},
+			Links: models.Links{Self: "self"},
 		}}
 		So(validateCosts(&cost), ShouldBeNil)
 	})
@@ -574,7 +561,7 @@ func TestUnitValidateCosts(t *testing.T) {
 				ClassOfPayment:          []string{"class"},
 				Description:             "desc",
 				DescriptionIdentifier:   "identifier",
-				Links:                   models.Links{Self: "self"},
+				Links: models.Links{Self: "self"},
 			},
 			{
 				Amount:                  "20",
@@ -582,7 +569,7 @@ func TestUnitValidateCosts(t *testing.T) {
 				ClassOfPayment:          []string{"class"},
 				Description:             "",
 				DescriptionIdentifier:   "identifier",
-				Links:                   models.Links{Self: "self"},
+				Links: models.Links{Self: "self"},
 			},
 		}
 		So(validateCosts(&cost), ShouldNotBeNil)

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -25,7 +25,7 @@ var defaultCost = models.CostResource{
 	ClassOfPayment:          []string{"class"},
 	Description:             "desc",
 	DescriptionIdentifier:   "identifier",
-	Links: models.Links{Self: "self"},
+	Links:                   models.Links{Self: "self"},
 }
 
 var defaultCostArray = []models.CostResource{
@@ -538,7 +538,7 @@ func TestUnitValidateCosts(t *testing.T) {
 			ClassOfPayment:          []string{"class"},
 			Description:             "",
 			DescriptionIdentifier:   "identifier",
-			Links: models.Links{Self: "self"},
+			Links:                   models.Links{Self: "self"},
 		}}
 		So(validateCosts(&cost), ShouldNotBeNil)
 	})
@@ -549,7 +549,7 @@ func TestUnitValidateCosts(t *testing.T) {
 			ClassOfPayment:          []string{"class"},
 			Description:             "desc",
 			DescriptionIdentifier:   "identifier",
-			Links: models.Links{Self: "self"},
+			Links:                   models.Links{Self: "self"},
 		}}
 		So(validateCosts(&cost), ShouldBeNil)
 	})
@@ -561,7 +561,7 @@ func TestUnitValidateCosts(t *testing.T) {
 				ClassOfPayment:          []string{"class"},
 				Description:             "desc",
 				DescriptionIdentifier:   "identifier",
-				Links: models.Links{Self: "self"},
+				Links:                   models.Links{Self: "self"},
 			},
 			{
 				Amount:                  "20",
@@ -569,7 +569,7 @@ func TestUnitValidateCosts(t *testing.T) {
 				ClassOfPayment:          []string{"class"},
 				Description:             "",
 				DescriptionIdentifier:   "identifier",
-				Links: models.Links{Self: "self"},
+				Links:                   models.Links{Self: "self"},
 			},
 		}
 		So(validateCosts(&cost), ShouldNotBeNil)


### PR DESCRIPTION
Gorilla pat, the router being used by the payents api, breaks the build with the latest version. There seems to be an issue when using route naming in gorilla pat. Moving to gorilla mux (a fully-fledged router that pat is based on) fixes this issue. 

I have updated the router, the unit tests and all code that depends on the router. There is slightly different syntax for retrieving path variables and setting new routes as can be seen below.

### Type of change

* [x ] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [x ] I have added unit tests for new code that I have added
* [x ] I have added/updated functional tests where appropriate
* [x ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__