### PR TITLE
Make Redirect_URI, Resource, and State mandatory elements

### DIFF
--- a/models/payment.go
+++ b/models/payment.go
@@ -4,10 +4,10 @@ import "time"
 
 // IncomingPaymentResourceRequest is the data received in the body of the incoming request
 type IncomingPaymentResourceRequest struct {
-	RedirectURI string `json:"redirect_uri"`
+	RedirectURI string `json:"redirect_uri"        validate:"required"`
 	Reference   string `json:"reference"`
-	Resource    string `json:"resource"`
-	State       string `json:"state"`
+	Resource    string `json:"resource"            validate:"required"`
+	State       string `json:"state"               validate:"required"`
 }
 
 // PaymentResource contains all payment details to be stored in the DB

--- a/service/external_paysession_test.go
+++ b/service/external_paysession_test.go
@@ -7,11 +7,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gorilla/mux"
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
 	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
 	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/jarcoal/httpmock.v1"
 )

--- a/service/payment.go
+++ b/service/payment.go
@@ -71,6 +71,12 @@ func (service *PaymentService) CreatePaymentSession(w http.ResponseWriter, req *
 		return
 	}
 
+	if err = validatePaymentCreate(incomingPaymentResourceRequest); err != nil {
+		log.ErrorR(req, fmt.Errorf("invalid POST request to create payment session: [%v]", err))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	costs, httpStatus, err := getCosts(incomingPaymentResourceRequest.Resource, &service.Config)
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error getting payment resource: [%v]", err))
@@ -357,6 +363,15 @@ func validateCosts(costs *[]models.CostResource) error {
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func validatePaymentCreate(incomingPaymentResourceRequest models.IncomingPaymentResourceRequest) error {
+	validate := validator.New()
+	err := validate.Struct(incomingPaymentResourceRequest)
+	if err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Make Redirect_URI, Resource, and State mandatory elements when sending POST request to create payment session. Leave Reference as an optional field. 

Resolves: CPS-196 
Fixes: CPS-240

### Type of change

* [X] Bug fix
* [X] New feature

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__