### PR TITLE
Adds etag and kind to the payment model

### DIFF
--- a/models/payment.go
+++ b/models/payment.go
@@ -32,6 +32,8 @@ type PaymentResourceData struct {
 	Reference               string         `json:"reference,omitempty"                 bson:"reference,omitempty"`
 	Status                  string         `json:"status"                              bson:"status"`
 	Costs                   []CostResource `json:"items"`
+	Etag                    string         `bson:"etag"`
+	Kind                    string         `bson:"kind"`
 }
 
 // CreatedBy is the user who is creating the payment session


### PR DESCRIPTION
Spec requires 2 fields to be added to the payment model: etag and kind. These are empty fields at the moment. I have created another ticket that will include the implementation of populating these fields when we receive more information from the lead devs/architects

CPS-254

### Type of change

* [x ] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [x ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__