### PR TITLE
Populate Kind field to adhere to api spec

### DIFF
--- a/service/payment.go
+++ b/service/payment.go
@@ -32,6 +32,9 @@ type PaymentService struct {
 // PaymentStatus Enum Type
 type PaymentStatus int
 
+// PaymentSessionKind
+const PaymentSessionKind = "payment-session#payment-session"
+
 // Enumeration containing all possible payment statuses
 const (
 	Pending PaymentStatus = 1 + iota
@@ -124,6 +127,7 @@ func (service *PaymentService) CreatePaymentSession(w http.ResponseWriter, req *
 	paymentResource.State = incomingPaymentResourceRequest.State
 	paymentResource.RedirectURI = incomingPaymentResourceRequest.RedirectURI
 	paymentResource.Data.Status = Pending.String()
+	paymentResource.Data.Kind = PaymentSessionKind
 	paymentResource.ID = generateID()
 
 	journeyURL := service.Config.PaymentsWebURL + "/payments/" + paymentResource.ID + "/pay"


### PR DESCRIPTION
Populate Kind field to adhere to api spec. The spec specifies the field must be populated from an enum: https://github.com/companieshouse/api.ch.gov.uk-specifications/blob/feature/transactions-acc-small-full/swagger-2.0/models/payments/payments.json