### PR TITLE
Change payment status to 'in-progress' when patch endpoint is called

### DIFF
--- a/service/external_paysession.go
+++ b/service/external_paysession.go
@@ -28,6 +28,11 @@ func (service *PaymentService) CreateExternalPaymentJourney(w http.ResponseWrite
 		log.ErrorR(req, err)
 		return
 	}
+	if paymentSession.Status != paymentStatuses[1] {
+		log.ErrorR(req, fmt.Errorf("payment session is not in progress"))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
 	paymentJourney := &models.ExternalPaymentJourney{}
 

--- a/service/external_paysession.go
+++ b/service/external_paysession.go
@@ -28,7 +28,7 @@ func (service *PaymentService) CreateExternalPaymentJourney(w http.ResponseWrite
 		log.ErrorR(req, err)
 		return
 	}
-	if paymentSession.Status != paymentStatuses[1] {
+	if paymentSession.Status != InProgress.String() {
 		log.ErrorR(req, fmt.Errorf("payment session is not in progress"))
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/service/external_paysession_test.go
+++ b/service/external_paysession_test.go
@@ -98,7 +98,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
-		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay", Status: paymentStatuses[1]}}, nil)
+		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay", Status: InProgress.String()}}, nil)
 
 		path := fmt.Sprintf("/payments/%s", "1234")
 		req, err := http.NewRequest("Get", path, nil)
@@ -123,7 +123,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
-		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay", Status: paymentStatuses[1]}}, nil)
+		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay", Status: InProgress.String()}}, nil)
 
 		path := fmt.Sprintf("/payments/%s", "1234")
 		req, err := http.NewRequest("Get", path, nil)
@@ -152,7 +152,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
-		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay", Status: paymentStatuses[1]}}, nil)
+		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay", Status: InProgress.String()}}, nil)
 		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(nil)
 
 		path := fmt.Sprintf("/payments/%s", "1234")

--- a/service/external_paysession_test.go
+++ b/service/external_paysession_test.go
@@ -45,6 +45,28 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		mockPaymentService.CreateExternalPaymentJourney(w, req)
 		So(w.Code, ShouldEqual, 500)
 	})
+	Convey("Payment session not in progress", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+
+		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay", Status: "paid"}}, nil)
+
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("Get", path, nil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
+		So(err, ShouldBeNil)
+
+		w := httptest.NewRecorder()
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		costArray := []models.CostResourceRest{defaultCost}
+		jsonResponse, _ := httpmock.NewJsonResponder(200, costArray)
+		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+
+		mockPaymentService.CreateExternalPaymentJourney(w, req)
+		So(w.Code, ShouldEqual, 400)
+	})
 
 	cfg.DomainWhitelist = "http://dummy-resource"
 	defer resetConfig()
@@ -76,7 +98,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
-		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay"}}, nil)
+		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay", Status: paymentStatuses[1]}}, nil)
 
 		path := fmt.Sprintf("/payments/%s", "1234")
 		req, err := http.NewRequest("Get", path, nil)
@@ -101,7 +123,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
-		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay"}}, nil)
+		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay", Status: paymentStatuses[1]}}, nil)
 
 		path := fmt.Sprintf("/payments/%s", "1234")
 		req, err := http.NewRequest("Get", path, nil)
@@ -130,7 +152,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
-		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay"}}, nil)
+		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay", Status: paymentStatuses[1]}}, nil)
 		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(nil)
 
 		path := fmt.Sprintf("/payments/%s", "1234")

--- a/service/external_paysession_test.go
+++ b/service/external_paysession_test.go
@@ -75,7 +75,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
-		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "PayPal"}}, nil)
+		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "PayPal", Status: InProgress.String()}}, nil)
 
 		path := fmt.Sprintf("/payments/%s", "1234")
 		req, err := http.NewRequest("Get", path, nil)
@@ -124,6 +124,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		mockPaymentService := createMockPaymentService(mock, cfg)
 
 		mock.EXPECT().GetPaymentResource("1234").Return(&models.PaymentResourceDB{ID: "1234", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}, PaymentMethod: "GovPay", Status: InProgress.String()}}, nil)
+		mock.EXPECT().PatchPaymentResource("1234", gomock.Any()).Return(nil)
 
 		path := fmt.Sprintf("/payments/%s", "1234")
 		req, err := http.NewRequest("Get", path, nil)

--- a/service/external_paysession_test.go
+++ b/service/external_paysession_test.go
@@ -45,6 +45,10 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		mockPaymentService.CreateExternalPaymentJourney(w, req)
 		So(w.Code, ShouldEqual, 500)
 	})
+
+	cfg.DomainWhitelist = "http://dummy-resource"
+	defer resetConfig()
+
 	Convey("Payment session not in progress", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
@@ -67,9 +71,6 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		mockPaymentService.CreateExternalPaymentJourney(w, req)
 		So(w.Code, ShouldEqual, 400)
 	})
-
-	cfg.DomainWhitelist = "http://dummy-resource"
-	defer resetConfig()
 
 	Convey("Invalid payment method", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)

--- a/service/payment.go
+++ b/service/payment.go
@@ -218,7 +218,7 @@ func (service *PaymentService) PatchPaymentSession(w http.ResponseWriter, req *h
 
 	requestDecoder := json.NewDecoder(req.Body)
 	var PaymentResourceUpdateData models.PaymentResourceRest
-	PaymentResourceUpdateData.Status = paymentStatuses[1]
+	PaymentResourceUpdateData.Status = InProgress.String()
 	err := requestDecoder.Decode(&PaymentResourceUpdateData)
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("request body invalid: [%v]", err))

--- a/service/payment.go
+++ b/service/payment.go
@@ -218,6 +218,7 @@ func (service *PaymentService) PatchPaymentSession(w http.ResponseWriter, req *h
 
 	requestDecoder := json.NewDecoder(req.Body)
 	var PaymentResourceUpdateData models.PaymentResourceRest
+	PaymentResourceUpdateData.Status = paymentStatuses[1]
 	err := requestDecoder.Decode(&PaymentResourceUpdateData)
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("request body invalid: [%v]", err))

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -461,9 +461,10 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBodyPatchInvalid))
 		req.Header.Set("Eric-Authorised-User", "test@companieshouse.gov.uk; forename=f; surname=s")
+		w := httptest.NewRecorder()
 
-		statusResponse, _ := mockPaymentService.patchPaymentSession("1234", models.PaymentResourceDB{})
-		So(statusResponse, ShouldEqual, 400)
+		mockPaymentService.PatchPaymentSession(w, req)
+		So(w.Code, ShouldEqual, 400)
 	})
 
 	Convey("Could not find payment resource to patch", t, func() {

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -461,10 +461,9 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 
 		req.Body = ioutil.NopCloser(bytes.NewReader(reqBodyPatchInvalid))
 		req.Header.Set("Eric-Authorised-User", "test@companieshouse.gov.uk; forename=f; surname=s")
-		w := httptest.NewRecorder()
 
-		mockPaymentService.PatchPaymentSession(w, req)
-		So(w.Code, ShouldEqual, 400)
+		statusResponse, _ := mockPaymentService.patchPaymentSession("1234", models.PaymentResourceDB{})
+		So(statusResponse, ShouldEqual, 400)
 	})
 
 	Convey("Could not find payment resource to patch", t, func() {


### PR DESCRIPTION
To fix the bug that already paid for payment sessions can have another external journey created for them a status update is now made when the payment is patched (just before the external journey endpoint is called). This status update changes the "status" of the payment to "in-progress", and any future external-journey calls will check to ensure that the status is in-progress before calling GovPay, else will throw an error. 

Resolves CPS-255

### Type of change

* [X] Bug fix

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__