### PR TITLE
As sha1 has been deprecated, use the more secure sha512 hash

### DIFF
--- a/service/payment.go
+++ b/service/payment.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"crypto/sha1"
+	"crypto/sha512"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -376,8 +376,8 @@ func generateEtag() string {
 	randomNumber := fmt.Sprintf("%07d", rand.Intn(9999999))
 	timeInMillis := strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10)
 	timeInSeconds := strconv.FormatInt(time.Now().UnixNano()/int64(time.Second), 10)
-	// Calculate a SHA-1 digest
-	shaDigest := sha1.New()
+	// Calculate a SHA-512 truncated digest
+	shaDigest := sha512.New512_224()
 	shaDigest.Write([]byte(randomNumber + timeInMillis + timeInSeconds))
 	sha1_hash := hex.EncodeToString(shaDigest.Sum(nil))
 	return sha1_hash


### PR DESCRIPTION
To generate the tag of a payment session, the sha1 hash function was being used. SHA-1 is cryptographically broken and should not be used for secure applications.

So this PR replaces it with sha512 which is much more secure to collision attacks.

CPS-268

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [x ] I have added unit tests for new code that I have added
* [x ] I have added/updated functional tests where appropriate
* [x ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__