### PR TITLE
Change patch request to only update status from pending to in-progress 

### DIFF
--- a/handlers/callback.go
+++ b/handlers/callback.go
@@ -2,8 +2,9 @@ package handlers
 
 import (
 	"fmt"
-	"github.com/gorilla/mux"
 	"net/http"
+
+	"github.com/gorilla/mux"
 
 	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
@@ -60,7 +61,7 @@ func HandleGovPayCallback(w http.ResponseWriter, req *http.Request) {
 
 	// Set the status of the payment
 	paymentSession.Status = statusResponse.Status
-	responseType, err = paymentService.PatchPaymentSession(id, *paymentSession)
+	responseType, err = paymentService.PatchPaymentSession(req, id, *paymentSession)
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error setting payment status: [%v]", err))
 		switch responseType {

--- a/handlers/callback.go
+++ b/handlers/callback.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gorilla/mux"
-
 	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
 	"github.com/companieshouse/payments.api.ch.gov.uk/service"
+	"github.com/gorilla/mux"
 )
 
 // HandleGovPayCallback handles the callback from Govpay and redirects the user

--- a/handlers/payments.go
+++ b/handlers/payments.go
@@ -141,7 +141,7 @@ func HandlePatchPaymentSession(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	responseType, err := paymentService.PatchPaymentSession(id, PaymentResourceUpdateData)
+	responseType, err := paymentService.PatchPaymentSession(req, id, PaymentResourceUpdateData)
 
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error patching payment resource: [%v]", err))

--- a/service/payment.go
+++ b/service/payment.go
@@ -141,11 +141,21 @@ func (service *PaymentService) CreatePaymentSession(req *http.Request, createRes
 }
 
 // PatchPaymentSession updates an existing payment session with the data provided from the Rest model
-func (service *PaymentService) PatchPaymentSession(id string, PaymentResourceUpdateRest models.PaymentResourceRest) (ResponseType, error) {
+func (service *PaymentService) PatchPaymentSession(req *http.Request, id string, PaymentResourceUpdateRest models.PaymentResourceRest) (ResponseType, error) {
 	PaymentResourceUpdate := transformers.PaymentTransformer{}.TransformToDB(PaymentResourceUpdateRest)
 	PaymentResourceUpdate.Data.Etag = generateEtag()
-	PaymentResourceUpdate.Data.Status = InProgress.String()
-	err := service.DAO.PatchPaymentResource(id, &PaymentResourceUpdate)
+
+	paymentSession, response, err := service.GetPaymentSession(req, id)
+	if err != nil {
+		err = fmt.Errorf("error getting payment resource to patch: [%v]", err)
+		log.ErrorR(req, err)
+		return response, err
+	}
+	if paymentSession.Status == Pending.String() {
+		PaymentResourceUpdate.Data.Status = InProgress.String()
+	}
+
+	err = service.DAO.PatchPaymentResource(id, &PaymentResourceUpdate)
 	if err != nil {
 		err = fmt.Errorf("error patching payment session on database: [%v]", err)
 		log.Error(err)


### PR DESCRIPTION
Fixed a bug where the payment status is always updated to 'In-Progress' when a payment session is patched. Now it is only updated if the session is patched when it is pending, the indicate that the session is in progress.

Resolves CPS-271

### Type of change

* [X] Bug fix

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__