### PR TITLE
Updated API Keys to be both treasury and CH Account accessible

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,15 +14,16 @@ var mtx sync.Mutex
 
 // Config defines the configuration options for this service.
 type Config struct {
-	BindAddr          string `env:"BIND_ADDR"            flag:"bind-addr"              flagDesc:"Bind address"`
-	Collection        string `env:"MONGODB_COLLECTION"   flag:"mongodb-collection"     flagDesc:"MongoDB collection for data"`
-	Database          string `env:"MONGODB_DATABASE"     flag:"mongodb-database"       flagDesc:"MongoDB database for data"`
-	MongoDBURL        string `env:"MONGODB_URL"          flag:"mongodb-url"            flagDesc:"MongoDB server URL"`
-	DomainWhitelist   string `env:"DOMAIN_WHITELIST"     flag:"domain-whitelist"       flagDesc:"List of Valid Domains"`
-	PaymentsWebURL    string `env:"PAYMENTS_WEB_URL"     flag:"payments-web-url"       flagDesc:"Base URL for the Payment Service Web"`
-	PaymentsApiURL    string `env:"PAYMENTS_API_URL"     flag:"payments-api-url"       flagDesc:"Base URL for the Payment Service API"`
-	GovPayURL         string `env:"GOV_PAY_URL"          flag:"gov-pay-url"            flagDesc:"URL used to make calls to GovPay"`
-	GovPayBearerToken string `env:"GOV_PAY_BEARER_TOKEN" flag:"gov-pay-bearer-token"   flagDesc:"Bearer Token used to authenticate API calls with GovPay"`
+	BindAddr                   string `env:"BIND_ADDR"                       flag:"bind-addr"                         flagDesc:"Bind address"`
+	Collection                 string `env:"MONGODB_COLLECTION"              flag:"mongodb-collection"                flagDesc:"MongoDB collection for data"`
+	Database                   string `env:"MONGODB_DATABASE"                flag:"mongodb-database"                  flagDesc:"MongoDB database for data"`
+	MongoDBURL                 string `env:"MONGODB_URL"                     flag:"mongodb-url"                       flagDesc:"MongoDB server URL"`
+	DomainWhitelist            string `env:"DOMAIN_WHITELIST"                flag:"domain-whitelist"                  flagDesc:"List of Valid Domains"`
+	PaymentsWebURL             string `env:"PAYMENTS_WEB_URL"                flag:"payments-web-url"                  flagDesc:"Base URL for the Payment Service Web"`
+	PaymentsApiURL             string `env:"PAYMENTS_API_URL"                flag:"payments-api-url"                  flagDesc:"Base URL for the Payment Service API"`
+	GovPayURL                  string `env:"GOV_PAY_URL"                     flag:"gov-pay-url"                       flagDesc:"URL used to make calls to GovPay"`
+	GovPayBearerTokenTreasury  string `env:"GOV_PAY_BEARER_TOKEN_TREASURY"   flag:"gov-pay-bearer-token-treasury"     flagDesc:"Bearer Token used to authenticate API calls with GovPay for treasury payments"`
+	GovPayBearerTokenChAccount string `env:"GOV_PAY_BEARER_TOKEN_CH_ACCOUNT" flag:"gov-pay-bearer-token-ch-account"   flagDesc:"Bearer Token used to authenticate API calls with GovPay for Companies House Payments"`
 }
 
 // DefaultConfig returns a pointer to a Config instance that has been populated

--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -62,7 +62,7 @@ func (gp *GovPayService) GenerateNextURLGovPay(req *http.Request, paymentResourc
 	}
 
 	request.Header.Add("accept", "application/json")
-	request.Header.Add("authorization", "Bearer "+gp.PaymentService.Config.GovPayBearerToken)
+	request.Header.Add("authorization", "Bearer "+gp.PaymentService.Config.GovPayBearerTokenTreasury) //Hardcoded to Treasury
 	request.Header.Add("content-type", "application/json")
 
 	resp, err := http.DefaultClient.Do(request)
@@ -101,7 +101,7 @@ func (gp *GovPayService) getGovPayPaymentState(paymentResource *models.PaymentRe
 	}
 
 	request.Header.Add("accept", "application/json")
-	request.Header.Add("authorization", "Bearer "+cfg.GovPayBearerToken)
+	request.Header.Add("authorization", "Bearer "+cfg.GovPayBearerTokenTreasury) //Hardcoded to Treasury
 	request.Header.Add("content-type", "application/json")
 
 	// Make call to GovPay to check state of payment

--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -62,7 +62,7 @@ func (gp *GovPayService) GenerateNextURLGovPay(req *http.Request, paymentResourc
 	}
 
 	request.Header.Add("accept", "application/json")
-	request.Header.Add("authorization", "Bearer "+gp.PaymentService.Config.GovPayBearerTokenTreasury) //Hardcoded to Treasury
+	request.Header.Add("authorization", "Bearer "+gp.PaymentService.Config.GovPayBearerTokenTreasury) //TODO: Determine which token to use
 	request.Header.Add("content-type", "application/json")
 
 	resp, err := http.DefaultClient.Do(request)
@@ -101,7 +101,7 @@ func (gp *GovPayService) getGovPayPaymentState(paymentResource *models.PaymentRe
 	}
 
 	request.Header.Add("accept", "application/json")
-	request.Header.Add("authorization", "Bearer "+cfg.GovPayBearerTokenTreasury) //Hardcoded to Treasury
+	request.Header.Add("authorization", "Bearer "+cfg.GovPayBearerTokenTreasury) //TODO: Determine which token to use
 	request.Header.Add("content-type", "application/json")
 
 	// Make call to GovPay to check state of payment


### PR DESCRIPTION
Updated the Bearer tokens so that in the future we will be able to switch between Treasury payments on GovPay and CH payments on GovPay, determining where the money will be directed.

Resolves: CPS-248

### Type of change

* [X] New feature

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__