### PR TITLE
check class of payments are same

### DIFF
--- a/service/external_paysession.go
+++ b/service/external_paysession.go
@@ -64,7 +64,7 @@ func validateClassOfPayment(costs *[]models.CostResourceRest) error {
 
 		//Check the Class Of Payments on separate resources are the same.
 		if (*costs)[i].ClassOfPayment[0] != (*costs)[0].ClassOfPayment[0] {
-			return fmt.Errorf("Two or more class of payments are different on the same transaction: [%v] and [%v] ", cost.Description[i], cost.Description[0])
+			return fmt.Errorf("Two or more class of payments are different on the same transaction: [%v] and [%v] ", (*costs)[0].Description, (*costs)[i].Description)
 		}
 	}
 	return nil

--- a/service/external_paysession.go
+++ b/service/external_paysession.go
@@ -20,7 +20,7 @@ func (service *PaymentService) CreateExternalPaymentJourney(req *http.Request, p
 	err := validateClassOfPayment(&paymentSession.Costs)
 	if err != nil {
 		log.ErrorR(req, err)
-		return InvalidData, nil, err
+		return nil, InvalidData, err
 	}
 
 	switch paymentSession.PaymentMethod {

--- a/service/external_paysession_test.go
+++ b/service/external_paysession_test.go
@@ -73,10 +73,15 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusCreated, &models.IncomingGovPayResponse{})
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, jsonResponse)
 
+		costResource := models.CostResourceRest{
+			ClassOfPayment: []string{"penalty"},
+		}
+
 		paymentSession := models.PaymentResourceRest{
 			PaymentMethod: "GovPay",
 			Amount:        "3",
 			Status:        InProgress.String(),
+			Costs:         []models.CostResourceRest{costResource},
 		}
 
 		externalPaymentJourney, responseType, err := mockPaymentService.CreateExternalPaymentJourney(req, &paymentSession)
@@ -103,10 +108,15 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		})
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, jsonResponse)
 
+		costResource := models.CostResourceRest{
+			ClassOfPayment: []string{"penalty"},
+		}
+
 		paymentSession := models.PaymentResourceRest{
 			PaymentMethod: "GovPay",
 			Amount:        "4",
 			Status:        InProgress.String(),
+			Costs:         []models.CostResourceRest{costResource},
 		}
 
 		externalPaymentJourney, responseType, err := mockPaymentService.CreateExternalPaymentJourney(req, &paymentSession)

--- a/service/external_paysession_test.go
+++ b/service/external_paysession_test.go
@@ -41,6 +41,63 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		So(err.Error(), ShouldEqual, "payment session is not in progress")
 	})
 
+	Convey("Class Of Payment different on same cost resource", t, func() {
+		mockPaymentService := createMockPaymentService(dao.NewMockDAO(mockCtrl), cfg)
+
+		req := httptest.NewRequest("", "/test", nil)
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		costResource := models.CostResourceRest{
+			ClassOfPayment: []string{"penalty", "data-maintenance"},
+			Description:    "mismatched cost resource",
+		}
+
+		paymentSession := models.PaymentResourceRest{
+			PaymentMethod: "GovPay",
+			Amount:        "3",
+			Status:        InProgress.String(),
+			Costs:         []models.CostResourceRest{costResource},
+		}
+
+		externalPaymentJourney, responseType, err := mockPaymentService.CreateExternalPaymentJourney(req, &paymentSession)
+		So(externalPaymentJourney, ShouldBeNil)
+		So(responseType.String(), ShouldEqual, InvalidData.String())
+		So(err.Error(), ShouldEqual, fmt.Sprintf("Two or more class of payments are different on the same cost resource: [%v] ", costResource.Description))
+	})
+
+	Convey("Class Of Payment different on different cost resources", t, func() {
+		mockPaymentService := createMockPaymentService(dao.NewMockDAO(mockCtrl), cfg)
+
+		req := httptest.NewRequest("", "/test", nil)
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		costResource1 := models.CostResourceRest{
+			ClassOfPayment: []string{"penalty"},
+			Description:    "penalty cost resource",
+		}
+
+		costResource2 := models.CostResourceRest{
+			ClassOfPayment: []string{"data-maintenance"},
+			Description:    "data-maintenance cost resource",
+		}
+
+		paymentSession := models.PaymentResourceRest{
+			PaymentMethod: "GovPay",
+			Amount:        "3",
+			Status:        InProgress.String(),
+			Costs:         []models.CostResourceRest{costResource1, costResource2},
+		}
+
+		externalPaymentJourney, responseType, err := mockPaymentService.CreateExternalPaymentJourney(req, &paymentSession)
+		So(externalPaymentJourney, ShouldBeNil)
+		So(responseType.String(), ShouldEqual, InvalidData.String())
+		So(err.Error(), ShouldEqual, fmt.Sprintf("Two or more class of payments are different on the same transaction: [%v] and [%v] ", costResource1.Description, costResource2.Description))
+	})
+
 	Convey("Error communicating with GOV.UK Pay", t, func() {
 		mockPaymentService := createMockPaymentService(dao.NewMockDAO(mockCtrl), cfg)
 
@@ -48,7 +105,6 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder("GET", cfg.GovPayURL, httpmock.NewStringResponder(400, "error"))
 
 		paymentSession := models.PaymentResourceRest{
 			PaymentMethod: "GovPay",

--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -61,8 +61,14 @@ func (gp *GovPayService) GenerateNextURLGovPay(req *http.Request, paymentResourc
 		return "", Error, fmt.Errorf("error generating request for GovPay: [%s]", err)
 	}
 
+	if paymentResource.Costs[0].ClassOfPayment[0] == "penalty" {
+		request.Header.Add("authorization", "Bearer "+gp.PaymentService.Config.GovPayBearerTokenTreasury)
+	}
+	if paymentResource.Costs[0].ClassOfPayment[0] == "data-maintenance" {
+		request.Header.Add("authorization", "Bearer "+gp.PaymentService.Config.GovPayBearerTokenChAccount)
+	}
+
 	request.Header.Add("accept", "application/json")
-	request.Header.Add("authorization", "Bearer "+gp.PaymentService.Config.GovPayBearerTokenTreasury) //TODO: Determine which token to use
 	request.Header.Add("content-type", "application/json")
 
 	resp, err := http.DefaultClient.Do(request)

--- a/service/gov_pay_test.go
+++ b/service/gov_pay_test.go
@@ -246,7 +246,7 @@ func TestUnitGenerateNextURLGovPay(t *testing.T) {
 		So(err.Error(), ShouldEqual, "error storing ExternalPaymentStatusURI for payment session: [error storing ExternalPaymentStatusURI on payment session: [error]]")
 	})
 
-	Convey("Valid request to GovPay and returned NextURL", t, func() {
+	Convey("Valid request to GovPay and returned NextURL for penalty", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)
 		mockGovPayService := createMockGovPayService(&mockPaymentService)
@@ -267,6 +267,42 @@ func TestUnitGenerateNextURLGovPay(t *testing.T) {
 
 		costResource := models.CostResourceRest{
 			ClassOfPayment: []string{"penalty"},
+		}
+
+		paymentResource := models.PaymentResourceRest{
+			Amount: "250",
+			Costs:  []models.CostResourceRest{costResource},
+		}
+
+		req := httptest.NewRequest("", "/test", nil)
+		govPayResponse, responseType, err := mockGovPayService.GenerateNextURLGovPay(req, &paymentResource)
+
+		So(responseType.String(), ShouldEqual, Success.String())
+		So(govPayResponse, ShouldEqual, journeyURL)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Valid request to GovPay and returned NextURL for data maintenance", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+		mockGovPayService := createMockGovPayService(&mockPaymentService)
+
+		mock.EXPECT().PatchPaymentResource(gomock.Any(), gomock.Any()).Return(nil)
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		journeyURL := "nextUrl"
+		NextURL := models.NextURL{HREF: journeyURL}
+		Self := models.Self{HREF: "paymentStatusURL"}
+
+		GovPayLinks := models.GovPayLinks{NextURL: NextURL, Self: Self}
+		IncomingGovPayResponse := models.IncomingGovPayResponse{GovPayLinks: GovPayLinks}
+
+		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusCreated, IncomingGovPayResponse)
+		httpmock.RegisterResponder("POST", cfg.GovPayURL, jsonResponse)
+
+		costResource := models.CostResourceRest{
+			ClassOfPayment: []string{"data-maintenance"},
 		}
 
 		paymentResource := models.PaymentResourceRest{

--- a/service/gov_pay_test.go
+++ b/service/gov_pay_test.go
@@ -112,7 +112,15 @@ func TestUnitGenerateNextURLGovPay(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, httpmock.NewErrorResponder(fmt.Errorf("error")))
 
-		paymentResource := models.PaymentResourceRest{Amount: "250.567"}
+		costResource := models.CostResourceRest{
+			ClassOfPayment: []string{"penalty"},
+		}
+
+		paymentResource := models.PaymentResourceRest{
+			Amount: "250.567",
+			Costs:  []models.CostResourceRest{costResource},
+		}
+
 		req := httptest.NewRequest("", "/test", nil)
 		govPayResponse, responseType, err := mockGovPayService.GenerateNextURLGovPay(req, &paymentResource)
 
@@ -130,7 +138,15 @@ func TestUnitGenerateNextURLGovPay(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, httpmock.NewErrorResponder(fmt.Errorf("error")))
 
-		paymentResource := models.PaymentResourceRest{Amount: "250"}
+		costResource := models.CostResourceRest{
+			ClassOfPayment: []string{"penalty"},
+		}
+
+		paymentResource := models.PaymentResourceRest{
+			Amount: "250",
+			Costs:  []models.CostResourceRest{costResource},
+		}
+
 		req := httptest.NewRequest("", "/test", nil)
 		govPayResponse, responseType, err := mockGovPayService.GenerateNextURLGovPay(req, &paymentResource)
 
@@ -150,7 +166,15 @@ func TestUnitGenerateNextURLGovPay(t *testing.T) {
 		jsonResponse, _ := httpmock.NewJsonResponder(500, "string")
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, jsonResponse)
 
-		paymentResource := models.PaymentResourceRest{Amount: "250"}
+		costResource := models.CostResourceRest{
+			ClassOfPayment: []string{"penalty"},
+		}
+
+		paymentResource := models.PaymentResourceRest{
+			Amount: "250",
+			Costs:  []models.CostResourceRest{costResource},
+		}
+
 		req := httptest.NewRequest("", "/test", nil)
 		govPayResponse, responseType, err := mockGovPayService.GenerateNextURLGovPay(req, &paymentResource)
 
@@ -171,7 +195,15 @@ func TestUnitGenerateNextURLGovPay(t *testing.T) {
 		jsonResponse, _ := httpmock.NewJsonResponder(500, IncomingGovPayResponse)
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, jsonResponse)
 
-		paymentResource := models.PaymentResourceRest{Amount: "250"}
+		costResource := models.CostResourceRest{
+			ClassOfPayment: []string{"penalty"},
+		}
+
+		paymentResource := models.PaymentResourceRest{
+			Amount: "250",
+			Costs:  []models.CostResourceRest{costResource},
+		}
+
 		req := httptest.NewRequest("", "/test", nil)
 		govPayResponse, responseType, err := mockGovPayService.GenerateNextURLGovPay(req, &paymentResource)
 
@@ -199,7 +231,15 @@ func TestUnitGenerateNextURLGovPay(t *testing.T) {
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusCreated, IncomingGovPayResponse)
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, jsonResponse)
 
-		paymentResource := models.PaymentResourceRest{Amount: "250"}
+		costResource := models.CostResourceRest{
+			ClassOfPayment: []string{"penalty"},
+		}
+
+		paymentResource := models.PaymentResourceRest{
+			Amount: "250",
+			Costs:  []models.CostResourceRest{costResource},
+		}
+
 		req := httptest.NewRequest("", "/test", nil)
 		_, _, err := mockGovPayService.GenerateNextURLGovPay(req, &paymentResource)
 
@@ -225,7 +265,15 @@ func TestUnitGenerateNextURLGovPay(t *testing.T) {
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusCreated, IncomingGovPayResponse)
 		httpmock.RegisterResponder("POST", cfg.GovPayURL, jsonResponse)
 
-		paymentResource := models.PaymentResourceRest{Amount: "250"}
+		costResource := models.CostResourceRest{
+			ClassOfPayment: []string{"penalty"},
+		}
+
+		paymentResource := models.PaymentResourceRest{
+			Amount: "250",
+			Costs:  []models.CostResourceRest{costResource},
+		}
+
 		req := httptest.NewRequest("", "/test", nil)
 		govPayResponse, responseType, err := mockGovPayService.GenerateNextURLGovPay(req, &paymentResource)
 


### PR DESCRIPTION
Added a validate method that checks that all classOfPayments within a transaction are the same and the resource can therefore be paid for. 
Once this has been established the classOfPayment is used to determine the bearer token that is sent to GovPay, and therefore the final destination of the payment. 

Resolves: LFA-446 

### Type of change

* [X] New feature

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__