### PR TITLE
Feature/remove repeated writeheader

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	GovPayURL                  string   `env:"GOV_PAY_URL"                     flag:"gov-pay-url"                       flagDesc:"URL used to make calls to GovPay"`
 	GovPayBearerTokenTreasury  string   `env:"GOV_PAY_BEARER_TOKEN_TREASURY"   flag:"gov-pay-bearer-token-treasury"     flagDesc:"Bearer Token used to authenticate API calls with GovPay for treasury payments"`
 	GovPayBearerTokenChAccount string   `env:"GOV_PAY_BEARER_TOKEN_CH_ACCOUNT" flag:"gov-pay-bearer-token-ch-account"   flagDesc:"Bearer Token used to authenticate API calls with GovPay for Companies House Payments"`
-	ExpiryTimeInMinutes        string   `env:"EXPIRY_TIME_IN_MINUTES"          flag:"expiry-time-in-minsutes"           flagDesc:"The expiry time for the payment session in minutes"`
+	ExpiryTimeInMinutes        string   `env:"EXPIRY_TIME_IN_MINUTES"          flag:"expiry-time-in-minutes"            flagDesc:"The expiry time for the payment session in minutes"`
 	BrokerAddr                 []string `env:"KAFKA_BROKER_ADDR"               flag:"broker-addr"                       flagDesc:"Kafka broker address"`
 	SchemaRegistryURL          string   `env:"SCHEMA_REGISTRY_URL"             flag:"schema-registry-url"               flagDesc:"Schema registry url"`
 }

--- a/handlers/external_paysession.go
+++ b/handlers/external_paysession.go
@@ -46,7 +46,5 @@ func HandleCreateExternalPaymentJourney(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
-
 	log.InfoR(req, "Successfully started session with GOV.UK Pay", log.Data{"payment_id": paymentSession.MetaData.ID, "status": http.StatusCreated})
 }


### PR DESCRIPTION
Remove duplication of writing status to header
(StatusOk is already written as part of the header writing on line 40).

This fix will remove a large amount of superfluous logging from stderr.

Also fixed a spelling mistake in config.go