### PR TITLE
Ensures validation is up to date with spec

### DIFF
--- a/handlers/callback_test.go
+++ b/handlers/callback_test.go
@@ -24,7 +24,6 @@ var defaultCost = models.CostResourceRest{
 	ClassOfPayment:          []string{"class"},
 	Description:             "desc",
 	DescriptionIdentifier:   "identifier",
-	Links:                   models.CostLinksRest{Self: "self"},
 }
 
 var defaultCosts = models.CostsRest{
@@ -112,7 +111,7 @@ func TestUnitHandleGovPayCallback(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-url", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-url/payment", jsonResponse)
 
 		req := httptest.NewRequest("GET", "/test", nil)
 		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
@@ -139,7 +138,7 @@ func TestUnitHandleGovPayCallback(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-url", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-url/payment", jsonResponse)
 
 		req := httptest.NewRequest("GET", "/test", nil)
 		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
@@ -166,7 +165,7 @@ func TestUnitHandleGovPayCallback(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-url", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-url/payment", jsonResponse)
 
 		req := httptest.NewRequest("GET", "/test", nil)
 		req = mux.SetURLVars(req, map[string]string{"payment_id": "123"})
@@ -193,7 +192,7 @@ func TestUnitHandleGovPayCallback(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-url", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-url/payment", jsonResponse)
 
 		req := httptest.NewRequest("GET", "/test", nil)
 		req = mux.SetURLVars(req, map[string]string{"payment_id": "123"})
@@ -221,7 +220,7 @@ func TestUnitHandleGovPayCallback(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-url", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-url/payment", jsonResponse)
 
 		govPayResponse := models.IncomingGovPayResponse{}
 		govPayJSONResponse, _ := httpmock.NewJsonResponder(200, govPayResponse)
@@ -253,7 +252,7 @@ func TestUnitHandleGovPayCallback(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jSONResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-url", jSONResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-url/payment", jSONResponse)
 
 		govPayResponse := models.IncomingGovPayResponse{}
 		govPayJSONResponse, _ := httpmock.NewJsonResponder(200, govPayResponse)
@@ -287,7 +286,7 @@ func TestUnitHandleGovPayCallback(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jSONResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-url", jSONResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-url/payment", jSONResponse)
 
 		govPayResponse := models.IncomingGovPayResponse{}
 		govPayJSONResponse, _ := httpmock.NewJsonResponder(200, govPayResponse)

--- a/interceptors/payment_authentication_test.go
+++ b/interceptors/payment_authentication_test.go
@@ -25,7 +25,6 @@ var defaultCostRest = models.CostResourceRest{
 	ClassOfPayment:          []string{"class"},
 	Description:             "desc",
 	DescriptionIdentifier:   "identifier",
-	Links:                   models.CostLinksRest{Self: "self"},
 }
 
 var defaultCosts = models.CostsRest{
@@ -221,7 +220,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		test := paymentAuthenticationInterceptor.PaymentAuthenticationIntercept(GetTestHandler())
 		test.ServeHTTP(w, req.WithContext(ctx))
@@ -262,7 +261,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		test := paymentAuthenticationInterceptor.PaymentAuthenticationIntercept(GetTestHandler())
 		test.ServeHTTP(w, req.WithContext(ctx))
@@ -303,7 +302,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		test := paymentAuthenticationInterceptor.PaymentAuthenticationIntercept(GetTestHandler())
 		test.ServeHTTP(w, req.WithContext(ctx))
@@ -344,7 +343,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		test := paymentAuthenticationInterceptor.PaymentAuthenticationIntercept(GetTestHandler())
 		test.ServeHTTP(w, req.WithContext(ctx))

--- a/models/payment_rest.go
+++ b/models/payment_rest.go
@@ -71,11 +71,4 @@ type CostResourceRest struct {
 	Description             string            `json:"description"               validate:"required"`
 	DescriptionIdentifier   string            `json:"description_identifier"    validate:"required"`
 	DescriptionValues       map[string]string `json:"description_values"`
-	Links                   CostLinksRest     `json:"links"                     validate:"required"`
-}
-
-// CostLinksRest is a set of URLs related to the resource, including self
-type CostLinksRest struct {
-	Resource string `json:"resource"`
-	Self     string `json:"self" validate:"required"`
 }

--- a/service/payment.go
+++ b/service/payment.go
@@ -244,7 +244,7 @@ func getTotalAmount(costs *[]models.CostResourceRest) (string, error) {
 
 func getCosts(resource string) (*models.CostsRest, ResponseType, error) {
 
-	resourceReq, err := http.NewRequest("GET", resource, nil)
+	resourceReq, err := http.NewRequest("GET", resource+"/payment", nil)
 	if err != nil {
 		return nil, Error, fmt.Errorf("failed to create Resource Request: [%v]", err)
 	}

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -23,7 +23,6 @@ var defaultCost = models.CostResourceRest{
 	ClassOfPayment:          []string{"class"},
 	Description:             "desc",
 	DescriptionIdentifier:   "identifier",
-	Links:                   models.CostLinksRest{Self: "self"},
 }
 
 var defaultCosts = models.CostsRest{
@@ -90,7 +89,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder("GET", "http://dummy-resource", nil)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", nil)
 
 		authUserDetails := models.AuthUserDetails{
 			ID: "identity",
@@ -107,7 +106,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		paymentResourceRest, status, err := mockPaymentService.CreatePaymentSession(req.WithContext(ctx), resource)
 		So(paymentResourceRest, ShouldBeNil)
 		So(status, ShouldEqual, Error)
-		So(err.Error(), ShouldEqual, "error getting payment resource: [error getting Cost Resource: [Get http://dummy-url: no responder found]]")
+		So(err.Error(), ShouldEqual, "error getting payment resource: [error getting Cost Resource: [Get http://dummy-url/payment: no responder found]]")
 	})
 
 	Convey("Error getting total amount from costs", t, func() {
@@ -123,7 +122,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 			Costs: []models.CostResourceRest{costResource},
 		}
 		jsonResponse, _ := httpmock.NewJsonResponder(200, costs)
-		httpmock.RegisterResponder("GET", "http://dummy-url", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-url/payment", jsonResponse)
 
 		authUserDetails := models.AuthUserDetails{
 			ID: "identity",
@@ -151,7 +150,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-url", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-url/payment", jsonResponse)
 
 		authUserDetails := models.AuthUserDetails{
 			ID: "identity",
@@ -181,7 +180,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-url", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-url/payment", jsonResponse)
 
 		ctx := context.WithValue(req.Context(), helpers.ContextKeyUserDetails, defaultUserDetails)
 
@@ -218,9 +217,9 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		So(paymentResourceRest.Status, ShouldEqual, "pending")
 		So(paymentResourceRest.Costs, ShouldResemble, defaultCosts.Costs)
 		So(paymentResourceRest.MetaData, ShouldResemble, models.PaymentResourceMetaDataRest{
-			ID:                       "",
-			RedirectURI:              "",
-			State:                    "",
+			ID:          "",
+			RedirectURI: "",
+			State:       "",
 			ExternalPaymentStatusURI: "",
 		})
 
@@ -238,7 +237,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		costs := defaultCosts
 		costs.Costs = append(costs.Costs, defaultCost)
 		jsonResponse, _ := httpmock.NewJsonResponder(200, costs)
-		httpmock.RegisterResponder("GET", "http://dummy-url", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-url/payment", jsonResponse)
 
 		ctx := context.WithValue(req.Context(), helpers.ContextKeyUserDetails, defaultUserDetails)
 
@@ -275,9 +274,9 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		So(paymentResourceRest.Status, ShouldEqual, "pending")
 		So(paymentResourceRest.Costs, ShouldResemble, []models.CostResourceRest{defaultCost, defaultCost})
 		So(paymentResourceRest.MetaData, ShouldResemble, models.PaymentResourceMetaDataRest{
-			ID:                       "",
-			RedirectURI:              "",
-			State:                    "",
+			ID:          "",
+			RedirectURI: "",
+			State:       "",
 			ExternalPaymentStatusURI: "",
 		})
 
@@ -302,7 +301,7 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		costArray := []models.CostResourceRest{defaultCost}
 		jsonResponse, _ := httpmock.NewJsonResponder(200, costArray)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		resource := models.PaymentResourceRest{}
 		responseType, err := mockPaymentService.PatchPaymentSession(req, "1234", resource)
@@ -322,7 +321,7 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		resource := models.PaymentResourceRest{}
 		responseType, err := mockPaymentService.PatchPaymentSession(req, "1234", resource)
@@ -340,7 +339,7 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		resource := models.PaymentResourceRest{
 			PaymentMethod: "GovPay",
@@ -393,12 +392,12 @@ func TestUnitGetPayment(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder("GET", "http://dummy-resource", nil)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", nil)
 
 		paymentResourceRest, status, err := mockPaymentService.GetPaymentSession(req, "1234")
 		So(paymentResourceRest, ShouldBeNil)
 		So(status, ShouldEqual, Error)
-		So(err.Error(), ShouldEqual, "error getting payment resource: [error getting Cost Resource: [Get : no responder found]]")
+		So(err.Error(), ShouldEqual, "error getting payment resource: [error getting Cost Resource: [Get /payment: no responder found]]")
 	})
 
 	cfg.DomainWhitelist = "http://dummy-resource"
@@ -426,7 +425,7 @@ func TestUnitGetPayment(t *testing.T) {
 		costs := defaultCosts
 		costs.Costs = costArray
 		jsonResponse, _ := httpmock.NewJsonResponder(200, costs)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		paymentResourceRest, status, err := mockPaymentService.GetPaymentSession(req, "1234")
 		So(paymentResourceRest, ShouldBeNil)
@@ -457,7 +456,7 @@ func TestUnitGetPayment(t *testing.T) {
 		costs := defaultCosts
 		costs.Costs = costArray
 		jsonResponse, _ := httpmock.NewJsonResponder(200, costs)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		paymentResourceRest, status, err := mockPaymentService.GetPaymentSession(req, "1234")
 		So(paymentResourceRest, ShouldBeNil)
@@ -484,7 +483,7 @@ func TestUnitGetPayment(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		paymentResourceRest, status, err := mockPaymentService.GetPaymentSession(req, "1234")
 		So(paymentResourceRest, ShouldResemble, &models.PaymentResourceRest{
@@ -500,9 +499,6 @@ func TestUnitGetPayment(t *testing.T) {
 					ClassOfPayment:          []string{"class"},
 					Description:             "desc",
 					DescriptionIdentifier:   "identifier",
-					Links: models.CostLinksRest{
-						Self: "self",
-					},
 				},
 			},
 			MetaData: models.PaymentResourceMetaDataRest{
@@ -534,7 +530,7 @@ func TestUnitGetPayment(t *testing.T) {
 		costs := defaultCosts
 		costs.Costs = append(costs.Costs, defaultCost)
 		jsonResponse, _ := httpmock.NewJsonResponder(200, costs)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		paymentResourceRest, status, err := mockPaymentService.GetPaymentSession(req, "1234")
 		So(paymentResourceRest, ShouldResemble, &models.PaymentResourceRest{
@@ -550,9 +546,6 @@ func TestUnitGetPayment(t *testing.T) {
 					ClassOfPayment:          []string{"class"},
 					Description:             "desc",
 					DescriptionIdentifier:   "identifier",
-					Links: models.CostLinksRest{
-						Self: "self",
-					},
 				},
 				{
 					Amount:                  "10",
@@ -560,9 +553,6 @@ func TestUnitGetPayment(t *testing.T) {
 					ClassOfPayment:          []string{"class"},
 					Description:             "desc",
 					DescriptionIdentifier:   "identifier",
-					Links: models.CostLinksRest{
-						Self: "self",
-					},
 				},
 			},
 			MetaData: models.PaymentResourceMetaDataRest{
@@ -599,19 +589,19 @@ func TestUnitGetCosts(t *testing.T) {
 	Convey("Error getting Cost Resource", t, func() {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder("GET", "http://dummy-resource", nil)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", nil)
 
 		costResourceRest, status, err := getCosts("http://dummy-resource")
 		So(costResourceRest, ShouldBeNil)
 		So(status, ShouldEqual, Error)
-		So(err.Error(), ShouldEqual, "error getting Cost Resource: [Get http://dummy-resource: no responder found]")
+		So(err.Error(), ShouldEqual, "error getting Cost Resource: [Get http://dummy-resource/payment: no responder found]")
 	})
 
 	Convey("Failure status when getting Cost Resource", t, func() {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(400, nil)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		costResourceRest, status, err := getCosts("http://dummy-resource")
 		So(costResourceRest, ShouldBeNil)
@@ -628,7 +618,7 @@ func TestUnitGetCosts(t *testing.T) {
 			Costs: []models.CostResourceRest{cost},
 		}
 		jsonResponse, _ := httpmock.NewJsonResponder(200, costs)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", "http://dummy-resource/payment", jsonResponse)
 
 		costResourceRest, status, err := getCosts("http://dummy-resource")
 		So(costResourceRest, ShouldBeNil)
@@ -684,7 +674,6 @@ func TestUnitValidateCosts(t *testing.T) {
 			ClassOfPayment:          []string{"class"},
 			Description:             "",
 			DescriptionIdentifier:   "identifier",
-			Links:                   models.CostLinksRest{Self: "self"},
 		}}
 		So(validateCosts(&cost), ShouldNotBeNil)
 	})
@@ -695,7 +684,6 @@ func TestUnitValidateCosts(t *testing.T) {
 			ClassOfPayment:          []string{"class"},
 			Description:             "desc",
 			DescriptionIdentifier:   "identifier",
-			Links:                   models.CostLinksRest{Self: "self"},
 		}}
 		So(validateCosts(&cost), ShouldBeNil)
 	})
@@ -707,7 +695,6 @@ func TestUnitValidateCosts(t *testing.T) {
 				ClassOfPayment:          []string{"class"},
 				Description:             "desc",
 				DescriptionIdentifier:   "identifier",
-				Links:                   models.CostLinksRest{Self: "self"},
 			},
 			{
 				Amount:                  "20",
@@ -715,7 +702,6 @@ func TestUnitValidateCosts(t *testing.T) {
 				ClassOfPayment:          []string{"class"},
 				Description:             "",
 				DescriptionIdentifier:   "identifier",
-				Links:                   models.CostLinksRest{Self: "self"},
 			},
 		}
 		So(validateCosts(&cost), ShouldNotBeNil)

--- a/transformers/payment_test.go
+++ b/transformers/payment_test.go
@@ -39,10 +39,6 @@ func TestUnitTransformToDB(t *testing.T) {
 					Description:             "desc1",
 					DescriptionIdentifier:   "desc_identifier1",
 					DescriptionValues:       map[string]string{"val": "val1"},
-					Links: models.CostLinksRest{
-						Resource: "resource1",
-						Self:     "self1",
-					},
 				},
 				{
 					Amount:                  "73",
@@ -51,10 +47,6 @@ func TestUnitTransformToDB(t *testing.T) {
 					Description:             "desc2",
 					DescriptionIdentifier:   "desc_identifier2",
 					DescriptionValues:       map[string]string{"val": "val2"},
-					Links: models.CostLinksRest{
-						Resource: "resource2",
-						Self:     "self2",
-					},
 				},
 			},
 		}


### PR DESCRIPTION
The validation was slightly behind the most recent specs, it expected a links block where the spec no longer requires it:

https://github.com/companieshouse/api.ch.gov.uk-specifications/blob/feature/transactions-acc-small-full/swagger-2.0/models/payments/payments.json

This PR also appends /payment to the resource url passed into the payments service as this is the expected behaviour.

### Type of change

* [x ] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [x ] I have added unit tests for new code that I have added
* [x ] I have added/updated functional tests where appropriate
* [x ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__