### PR TITLE
Add cancelled status and bearer token checks

### DIFF
--- a/models/gov_pay.go
+++ b/models/gov_pay.go
@@ -29,6 +29,7 @@ type IncomingGovPayResponse struct {
 type State struct {
 	Status   string `json:"status"`
 	Finished bool   `json:"finished"`
+	Code     string `json:"code"`
 }
 
 // RefundSummary is the refund status of the payment


### PR DESCRIPTION
When cancelling the journey from GovPay, a "cancelled" status is now returned. 

Error codes can be found here: https://docs.payments.service.gov.uk/api_reference/#errors-caused-by-an-api-call

Also, when getting the status of a payment from GovPay, only one bearer token was being used. This PR adds a check to determine which token to use (Treasury or CH Account).

SFA-1747

### Type of change

* [x ] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [x ] I have added unit tests for new code that I have added
* [x ] I have added/updated functional tests where appropriate
* [x ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__