### PR TITLE
use external_payment_id for gov pay id in payment details response

### DIFF
--- a/models/gov_pay.go
+++ b/models/gov_pay.go
@@ -101,8 +101,8 @@ type Cancel struct {
 
 // PaymentDetails is used by the payment-details endpoint to return card type and an auth number which is the payment id
 type PaymentDetails struct {
-	CardType        string `json:"card_type"`
-	PaymentID       string `json:"payment_id"`
-	TransactionDate string `json:"transaction_date"`
-	PaymentStatus   string `json:"payment_status"`
+	CardType          string `json:"card_type"`
+	ExternalPaymentID string `json:"external_payment_id"`
+	TransactionDate   string `json:"transaction_date"`
+	PaymentStatus     string `json:"payment_status"`
 }

--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -123,7 +123,7 @@ func (gp *GovPayService) GetGovPayPaymentDetails(paymentResource *models.Payment
 		return nil, Error, err
 	}
 
-	paymentDetails := &models.PaymentDetails{CardType: govPayResponse.CardBrand, PaymentID: govPayResponse.PaymentID, TransactionDate: govPayResponse.CreatedDate}
+	paymentDetails := &models.PaymentDetails{CardType: govPayResponse.CardBrand, ExternalPaymentID: govPayResponse.PaymentID, TransactionDate: govPayResponse.CreatedDate}
 
 	if govPayResponse.State.Finished && govPayResponse.State.Status == "success" {
 		paymentDetails.PaymentStatus = "accepted"

--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -51,7 +51,7 @@ func (gp *GovPayService) GenerateNextURLGovPay(req *http.Request, paymentResourc
 
 	govPayRequest.Amount = amountToPay
 	govPayRequest.Description = "Companies House Payment" // Hard-coded value for payment screens
-	govPayRequest.Reference = paymentResource.Reference
+	govPayRequest.Reference = paymentResource.MetaData.ID
 	govPayRequest.ReturnURL = fmt.Sprintf("%s/callback/payments/govpay/%s", gp.PaymentService.Config.PaymentsAPIURL, paymentResource.MetaData.ID)
 	log.TraceR(req, "performing gov pay request", log.Data{"gov_pay_request_data": govPayRequest})
 

--- a/service/gov_pay_test.go
+++ b/service/gov_pay_test.go
@@ -3,10 +3,11 @@ package service
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/jarcoal/httpmock.v1"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"gopkg.in/jarcoal/httpmock.v1"
 
 	"github.com/companieshouse/payments.api.ch.gov.uk/config"
 	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
@@ -465,7 +466,7 @@ func TestUnitGetGovPayPaymentDetails(t *testing.T) {
 
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		govPayPaymentDetails := models.PaymentDetails{CardType: "Visa", PaymentID: "1234", TransactionDate: "2016-01-21T17:15:000Z", PaymentStatus: "accepted"}
+		govPayPaymentDetails := models.PaymentDetails{CardType: "Visa", ExternalPaymentID: "1234", TransactionDate: "2016-01-21T17:15:000Z", PaymentStatus: "accepted"}
 		govPayState := models.State{Status: "success", Finished: true}
 		incomingGovPayResponse := models.IncomingGovPayResponse{CardBrand: "Visa", PaymentID: "1234", CreatedDate: "2016-01-21T17:15:000Z", State: govPayState}
 

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -187,10 +187,10 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		ctx := context.WithValue(req.Context(), authentication.ContextKeyUserDetails, defaultUserDetails)
 
 		resource := models.IncomingPaymentResourceRequest{
-			Resource:      "http://dummy-url",
-			Reference:     "ref",
-			RedirectURI:   "http://www.companieshouse.gov.uk",
-			State:         "state",
+			Resource:    "http://dummy-url",
+			Reference:   "ref",
+			RedirectURI: "http://www.companieshouse.gov.uk",
+			State:       "state",
 		}
 
 		paymentResourceRest, status, err := mockPaymentService.CreatePaymentSession(req.WithContext(ctx), resource)
@@ -220,9 +220,9 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		So(paymentResourceRest.Status, ShouldEqual, "pending")
 		So(paymentResourceRest.Costs, ShouldResemble, defaultCosts.Costs)
 		So(paymentResourceRest.MetaData, ShouldResemble, models.PaymentResourceMetaDataRest{
-			ID:          "",
-			RedirectURI: "",
-			State:       "",
+			ID:                       "",
+			RedirectURI:              "",
+			State:                    "",
 			ExternalPaymentStatusURI: "",
 		})
 
@@ -245,10 +245,10 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		ctx := context.WithValue(req.Context(), authentication.ContextKeyUserDetails, defaultUserDetails)
 
 		resource := models.IncomingPaymentResourceRequest{
-			Resource:      "http://dummy-url",
-			Reference:     "ref",
-			RedirectURI:   "http://www.companieshouse.gov.uk",
-			State:         "state",
+			Resource:    "http://dummy-url",
+			Reference:   "ref",
+			RedirectURI: "http://www.companieshouse.gov.uk",
+			State:       "state",
 		}
 
 		paymentResourceRest, status, err := mockPaymentService.CreatePaymentSession(req.WithContext(ctx), resource)
@@ -278,9 +278,9 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		So(paymentResourceRest.Status, ShouldEqual, "pending")
 		So(paymentResourceRest.Costs, ShouldResemble, []models.CostResourceRest{defaultCost, defaultCost})
 		So(paymentResourceRest.MetaData, ShouldResemble, models.PaymentResourceMetaDataRest{
-			ID:          "",
-			RedirectURI: "",
-			State:       "",
+			ID:                       "",
+			RedirectURI:              "",
+			State:                    "",
 			ExternalPaymentStatusURI: "",
 		})
 

--- a/transformers/payment.go
+++ b/transformers/payment.go
@@ -58,9 +58,9 @@ func (pt PaymentTransformer) TransformToRest(dbResource models.PaymentResourceDB
 
 	// One-way transformation of DB metadata: related to, but not part of the payment rest data json spec
 	paymentResource.MetaData = models.PaymentResourceMetaDataRest{
-		ID:          dbResource.ID,
-		RedirectURI: dbResource.RedirectURI,
-		State:       dbResource.State,
+		ID:                       dbResource.ID,
+		RedirectURI:              dbResource.RedirectURI,
+		State:                    dbResource.State,
 		ExternalPaymentStatusURI: dbResource.ExternalPaymentStatusURI,
 	}
 


### PR DESCRIPTION
change field name for card details response to make it clear that the id is for the external payment data i.e. the gov pay id