### PR TITLE
changed id generator so that it is alpha numeric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ test: test-unit test-integration
 test-unit: test-deps
 	set -a; go test $(TESTS) -run 'Unit'
 
+.PHONY: test-util
+test-util:
+	set -a; go test $(TESTS) -run 'Util'
+
 .PHONY: test-integration
 test-integration: test-deps
 	$(source_env); go test $(TESTS) -run 'Integration'

--- a/service/payment.go
+++ b/service/payment.go
@@ -284,7 +284,12 @@ func getCosts(resource string, cfg *config.Config) (*models.CostsRest, ResponseT
 	return costs, Success, nil
 }
 
-// Generates a string of 15 alpha numeric characters
+// Generates a string of 15 alpha numeric characters. this needs to be less than 16 characters as these id's are also
+// being sent to E5 (our finance system) when paying for late filing penalties. Although this restriction is currently
+// being imposed on us by an external system, there is enough entropy here that makes collisions highly unlikely, with
+// a total range being 15**62.
+//
+// **If you change the implementation of this test, you must run the utility test `go test ./... -run 'Util'**
 func generateID() string {
 	idLength := 15
 	rand.Seed(time.Now().UTC().UnixNano())

--- a/service/payment.go
+++ b/service/payment.go
@@ -6,14 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/companieshouse/chs.go/authentication"
-	"github.com/companieshouse/chs.go/log"
-	"github.com/companieshouse/payments.api.ch.gov.uk/config"
-	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
-	"github.com/companieshouse/payments.api.ch.gov.uk/models"
-	"github.com/companieshouse/payments.api.ch.gov.uk/transformers"
-	"github.com/shopspring/decimal"
-	"gopkg.in/go-playground/validator.v9"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -22,6 +14,15 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/companieshouse/chs.go/authentication"
+	"github.com/companieshouse/chs.go/log"
+	"github.com/companieshouse/payments.api.ch.gov.uk/config"
+	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
+	"github.com/companieshouse/payments.api.ch.gov.uk/models"
+	"github.com/companieshouse/payments.api.ch.gov.uk/transformers"
+	"github.com/shopspring/decimal"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // PaymentService contains the DAO for db access
@@ -283,12 +284,16 @@ func getCosts(resource string, cfg *config.Config) (*models.CostsRest, ResponseT
 	return costs, Success, nil
 }
 
-// Generates a string of 20 numbers made up of 7 random numbers, followed by 13 numbers derived from the current time
-func generateID() (i string) {
+// Generates a string of 15 alpha numeric characters
+func generateID() string {
+	idLength := 15
 	rand.Seed(time.Now().UTC().UnixNano())
-	ranNumber := fmt.Sprintf("%07d", rand.Intn(9999999))
-	millis := strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10)
-	return ranNumber + millis
+	chars := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890")
+	id := make([]rune, idLength)
+	for i := 0; i < idLength; i++ {
+		id[i] = chars[rand.Intn(len(chars))]
+	}
+	return string(id)
 }
 
 // generateEtag generates a random etag which is generated on every write action on the payment session

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -634,7 +634,9 @@ func TestUnitGetCosts(t *testing.T) {
 	})
 }
 
-func TestUtilGenerateID(t *testing.T) {
+// TestUtilGenerateIDForDuplicates this will test the generateID func's capability for generating unique id's
+// if a duplicate is generated, this test will fail.
+func TestUtilGenerateIDForDuplicates(t *testing.T) {
 	// generate 100,000 id's
 	times := 100000 // 100 thousand
 	generated := make([]string, times)
@@ -664,10 +666,8 @@ func TestUtilGenerateID(t *testing.T) {
 }
 
 func TestUnitGenerateID(t *testing.T) {
-	Convey("generateID", t, func() {
-		Convey("generates a id with a length of 15", func() {
-			So(generateID(), ShouldHaveLength, 15)
-		})
+	Convey("generates a id with a length of 15", t, func() {
+		So(generateID(), ShouldHaveLength, 15)
 	})
 }
 

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -635,9 +635,38 @@ func TestUnitGetCosts(t *testing.T) {
 }
 
 func TestUnitGenerateID(t *testing.T) {
-	Convey("Valid generated PaymentResource ID", t, func() {
-		re := regexp.MustCompile("^[0-9]{20}$")
-		So(re.MatchString(generateID()), ShouldEqual, true)
+	Convey("generateID", t, func() {
+		Convey("generates a id with a length of 15", func() {
+			So(generateID(), ShouldHaveLength, 15)
+		})
+		Convey("has a low collision rate", func() {
+			// generate 100,000 id's
+			times := 100000 // 100 thousand
+			generated := make([]string, times)
+
+			for i := 0; i < times; i++ {
+				ref := generateID()
+				generated[i] = ref
+			}
+
+			// check for dups by creating a map of string->int and counting the the entry values whilst
+			// iterating through the generated map
+			generatedCheck := make(map[string]int)
+			var duplicates []string
+			for _, reference := range generated {
+				_, exists := generatedCheck[reference]
+				if exists {
+					duplicates = append(duplicates, reference)
+				} else {
+					generatedCheck[reference] = 1
+				}
+			}
+
+			if  len(duplicates) != 0 {
+				t.Errorf("%d duplicate id's generated", len(duplicates))
+				t.Fail()
+			}
+		})
 	})
 }
 

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -634,38 +634,39 @@ func TestUnitGetCosts(t *testing.T) {
 	})
 }
 
+func TestUtilGenerateID(t *testing.T) {
+	// generate 100,000 id's
+	times := 100000 // 100 thousand
+	generated := make([]string, times)
+
+	for i := 0; i < times; i++ {
+		ref := generateID()
+		generated[i] = ref
+	}
+
+	// check for dups by creating a map of string->int and counting the the entry values whilst
+	// iterating through the generated map
+	generatedCheck := make(map[string]int)
+	var duplicates []string
+	for _, reference := range generated {
+		_, exists := generatedCheck[reference]
+		if exists {
+			duplicates = append(duplicates, reference)
+		} else {
+			generatedCheck[reference] = 1
+		}
+	}
+
+	if  len(duplicates) != 0 {
+		t.Errorf("%d duplicate id's generated", len(duplicates))
+		t.Fail()
+	}
+}
+
 func TestUnitGenerateID(t *testing.T) {
 	Convey("generateID", t, func() {
 		Convey("generates a id with a length of 15", func() {
 			So(generateID(), ShouldHaveLength, 15)
-		})
-		Convey("has a low collision rate", func() {
-			// generate 100,000 id's
-			times := 100000 // 100 thousand
-			generated := make([]string, times)
-
-			for i := 0; i < times; i++ {
-				ref := generateID()
-				generated[i] = ref
-			}
-
-			// check for dups by creating a map of string->int and counting the the entry values whilst
-			// iterating through the generated map
-			generatedCheck := make(map[string]int)
-			var duplicates []string
-			for _, reference := range generated {
-				_, exists := generatedCheck[reference]
-				if exists {
-					duplicates = append(duplicates, reference)
-				} else {
-					generatedCheck[reference] = 1
-				}
-			}
-
-			if  len(duplicates) != 0 {
-				t.Errorf("%d duplicate id's generated", len(duplicates))
-				t.Fail()
-			}
 		})
 	})
 }


### PR DESCRIPTION
Changes the generateID function so that it creates a string of alpha numeric characters with a length of 15. Unit test added to test for collisions after calling it 100,000 times.

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__