### PR TITLE
Pci 606 create a new class of payment

### DIFF
--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -71,6 +71,9 @@ func (gp *GovPayService) GenerateNextURLGovPay(req *http.Request, paymentResourc
 	if paymentResource.Costs[0].ClassOfPayment[0] == "data-maintenance" {
 		request.Header.Add("authorization", "Bearer "+gp.PaymentService.Config.GovPayBearerTokenChAccount)
 	}
+	if paymentResource.Costs[0].ClassOfPayment[0] == "orderable-item" {
+		request.Header.Add("authorization", "Bearer "+gp.PaymentService.Config.GovPayBearerTokenChAccount)
+	}
 
 	request.Header.Add("accept", "application/json")
 	request.Header.Add("content-type", "application/json")

--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -68,10 +68,8 @@ func (gp *GovPayService) GenerateNextURLGovPay(req *http.Request, paymentResourc
 	if paymentResource.Costs[0].ClassOfPayment[0] == "penalty" {
 		request.Header.Add("authorization", "Bearer "+gp.PaymentService.Config.GovPayBearerTokenTreasury)
 	}
-	if paymentResource.Costs[0].ClassOfPayment[0] == "data-maintenance" {
-		request.Header.Add("authorization", "Bearer "+gp.PaymentService.Config.GovPayBearerTokenChAccount)
-	}
-	if paymentResource.Costs[0].ClassOfPayment[0] == "orderable-item" {
+	if paymentResource.Costs[0].ClassOfPayment[0] == "data-maintenance" ||
+		paymentResource.Costs[0].ClassOfPayment[0] == "orderable-item" {
 		request.Header.Add("authorization", "Bearer "+gp.PaymentService.Config.GovPayBearerTokenChAccount)
 	}
 

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/companieshouse/payments.api.ch.gov.uk/dao"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
 	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
 	"github.com/jarcoal/httpmock"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 var defaultCost = models.CostResourceRest{
@@ -659,7 +659,7 @@ func TestUnitGenerateIDForDuplicates(t *testing.T) {
 		}
 	}
 
-	if  len(duplicates) != 0 {
+	if len(duplicates) != 0 {
 		t.Errorf("%d duplicate id's generated", len(duplicates))
 		t.Fail()
 	}


### PR DESCRIPTION
This PR introduces handling for a new payment class `orderable-item` for payments requested on behalf of Orders Service.
