### PR TITLE
Output status as a string to be consistent with other apps logging

### DIFF
--- a/handlers/callback.go
+++ b/handlers/callback.go
@@ -115,7 +115,7 @@ func HandleGovPayCallback(w http.ResponseWriter, req *http.Request) {
 		Status: paymentSession.Status,
 	}
 
-	log.InfoR(req, "Successfully Closed payment session", log.Data{"payment_id": id, "status": *statusResponse})
+	log.InfoR(req, "Successfully Closed payment session", log.Data{"payment_id": id, "status": paymentSession.Status})
 
 	err = handleKafkaMessage(paymentSession.MetaData.ID)
 	if err != nil {


### PR DESCRIPTION
Status is being output as a string in other applications. This change makes the status log field consistent with other applications.

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__