### PR TITLE
clean up unused dependencies using go mod tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ test-integration:
 
 .PHONY: clean
 clean:
+	go mod tidy 
 	rm -f ./$(bin) ./$(bin)-*.zip $(test_path) build.log
 
 .PHONY: package


### PR DESCRIPTION
- Clean up unused dependencies using `go mod tidy`.