### PR TITLE
Return 404 when payment resource is not found while refunding

### DIFF
--- a/handlers/refunds.go
+++ b/handlers/refunds.go
@@ -50,6 +50,9 @@ func HandleCreateRefund(w http.ResponseWriter, req *http.Request) {
 		case service.Error:
 			w.WriteHeader(http.StatusInternalServerError)
 			return
+		case service.NotFound:
+			w.WriteHeader(http.StatusNotFound)
+			return
 		default:
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -181,10 +181,12 @@ func (gp *GovPayService) GetGovPayRefundSummary(req *http.Request, id string) (*
 	case RefundPending:
 		err = errors.New("cannot refund the payment - the user has not completed the payment")
 		return nil, nil, InvalidData, err
+	case RefundAvailable:
+		return paymentSession, &govPayResponse.RefundSummary, Success, nil
+	default:
+		err = errors.New("cannot refund the payment - payment information not found")
+		return nil, nil, NotFound, err
 	}
-
-	// Return the payment session info and refund summary
-	return paymentSession, &govPayResponse.RefundSummary, Success, nil
 }
 
 // CreateRefund creates a refund in GovPay

--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -156,6 +156,13 @@ func (gp *GovPayService) GetGovPayRefundSummary(req *http.Request, id string) (*
 		return nil, nil, response, err
 	}
 
+	if response == NotFound {
+		err = fmt.Errorf("error getting payment resource")
+		log.ErrorR(req, err)
+
+		return nil, nil, NotFound, err
+	}
+
 	govPayResponse, err := callGovPay(gp, paymentSession)
 	if err != nil {
 		err = fmt.Errorf("error getting payment information from gov pay: [%v]", err)

--- a/service/gov_pay_test.go
+++ b/service/gov_pay_test.go
@@ -550,6 +550,23 @@ func TestUnitGetGovPayRefundSummary(t *testing.T) {
 		So(err.Error(), ShouldEqual, "error getting payment resource: [error getting payment resource from db: [error]]")
 	})
 
+	Convey("Payment resource not found in db", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+		mockGovPayService := createMockGovPayService(&mockPaymentService)
+		req := httptest.NewRequest("", "/test", nil)
+		id := "123"
+
+		mock.EXPECT().GetPaymentResource(id).Return(nil, nil)
+
+		paymentResource, refundSummary, responseType, err := mockGovPayService.GetGovPayRefundSummary(req, id)
+
+		So(responseType.String(), ShouldEqual, NotFound.String())
+		So(paymentResource, ShouldBeNil)
+		So(refundSummary, ShouldBeNil)
+		So(err.Error(), ShouldEqual, "error getting payment resource")
+	})
+
 	Convey("Error sending request to GovPay", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		mockPaymentService := createMockPaymentService(mock, cfg)

--- a/service/gov_pay_test.go
+++ b/service/gov_pay_test.go
@@ -726,6 +726,40 @@ func TestUnitGetGovPayRefundSummary(t *testing.T) {
 		So(refundSummary.AmountSubmitted, ShouldEqual, incomingGovPayResponse.RefundSummary.AmountSubmitted)
 		So(err, ShouldBeNil)
 	})
+
+	Convey("Refund information has no status", t, func() {
+		mock := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mock, cfg)
+		mockGovPayService := createMockGovPayService(&mockPaymentService)
+		req := httptest.NewRequest("", "/test", nil)
+		id := "123"
+
+		mock.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResourceDB{ID: "1234", ExternalPaymentStatusURI: "http://external_uri", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}}}, nil)
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
+		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+
+		govPayState := models.State{Status: "success", Finished: true}
+		incomingGovPayResponse := models.IncomingGovPayResponse{CardBrand: "Visa", PaymentID: "1234", CreatedDate: "2016-01-21T17:15:000Z", State: govPayState, RefundSummary: models.RefundSummary{
+			Status:          "",
+			AmountAvailable: 0,
+			AmountSubmitted: 0,
+		}}
+
+		govPayResponse, _ := httpmock.NewJsonResponder(http.StatusOK, incomingGovPayResponse)
+		httpmock.RegisterResponder("GET", "http://external_uri", govPayResponse)
+
+		paymentResource, refundSummary, responseType, err := mockGovPayService.GetGovPayRefundSummary(req, id)
+
+		So(responseType.String(), ShouldEqual, NotFound.String())
+		So(paymentResource, ShouldBeNil)
+		So(refundSummary, ShouldBeNil)
+
+		So(err.Error(), ShouldEqual, "cannot refund the payment - payment information not found")
+	})
 }
 
 func TestUnitGovPayCreateRefund(t *testing.T) {


### PR DESCRIPTION
Fixes 502 being returned when payment resource is not found in MongoDb
Fixes 500 being returned when payment resource is not found in GovPay when issuing a refund

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__