### PR TITLE
Close kafka producer after call to fix memory leakage

### DIFF
--- a/handlers/kafka_helper.go
+++ b/handlers/kafka_helper.go
@@ -68,6 +68,7 @@ func produceKafkaMessage(paymentID string, refundID string) error {
 		err = fmt.Errorf("error creating kafka producer: [%v]", err)
 		return err
 	}
+	defer kafkaProducer.Close()
 	paymentProcessedSchema, err := schema.Get(cfg.SchemaRegistryURL, ProducerSchemaName)
 	if err != nil {
 		err = fmt.Errorf("error getting schema from schema registry: [%v]", err)

--- a/handlers/kafka_helper.go
+++ b/handlers/kafka_helper.go
@@ -68,7 +68,7 @@ func produceKafkaMessage(paymentID string, refundID string) error {
 		err = fmt.Errorf("error creating kafka producer: [%v]", err)
 		return err
 	}
-	defer kafkaProducer.Close()
+	defer closeKafkaProducer(kafkaProducer, paymentID)
 	paymentProcessedSchema, err := schema.Get(cfg.SchemaRegistryURL, ProducerSchemaName)
 	if err != nil {
 		err = fmt.Errorf("error getting schema from schema registry: [%v]", err)
@@ -109,4 +109,12 @@ func prepareKafkaMessage(paymentID string, refundID string, paymentProcessedSche
 		Topic: ProducerTopic,
 	}
 	return producerMessage, nil
+}
+
+// closeKafkaProducer closes the kafkaProducer after the message has been sent
+func closeKafkaProducer(kafkaProducer *producer.Producer, paymentID string) {
+	err := kafkaProducer.Close()
+	if err != nil {
+		log.Error(fmt.Errorf("error closing kafka producer for payment ID [%s]", paymentID))
+	}
 }


### PR DESCRIPTION
Close the kafka producer after the return from GovPay. This fixes the memory leak issue. 

Resolves: BI-5994

### Type of change

* [X] Bug fix

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__