### PR TITLE
Send email address to GovPay when creating an external resource

### DIFF
--- a/models/gov_pay.go
+++ b/models/gov_pay.go
@@ -3,6 +3,7 @@ package models
 // OutgoingGovPayRequest is the request sent to GovPay to initiate a payment session
 type OutgoingGovPayRequest struct {
 	Amount      int    `json:"amount"`
+	Email       string `json:"email"`
 	Reference   string `json:"reference"`
 	ReturnURL   string `json:"return_url"`
 	Description string `json:"description"`

--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -60,6 +60,7 @@ func (gp *GovPayService) GenerateNextURLGovPay(req *http.Request, paymentResourc
 	}
 
 	govPayRequest.Amount = amountToPay
+	govPayRequest.Email = paymentResource.CreatedBy.Email
 	govPayRequest.Description = "Companies House Payment" // Hard-coded value for payment screens
 	govPayRequest.Reference = paymentResource.MetaData.ID
 	govPayRequest.ReturnURL = fmt.Sprintf("%s/callback/payments/govpay/%s", gp.PaymentService.Config.PaymentsAPIURL, paymentResource.MetaData.ID)

--- a/service/gov_pay_test.go
+++ b/service/gov_pay_test.go
@@ -162,6 +162,9 @@ func TestUnitGenerateNextURLGovPay(t *testing.T) {
 
 		paymentResource := models.PaymentResourceRest{
 			Amount: "250.567",
+			CreatedBy: models.CreatedByRest{
+				Email: "demo@demo.uk",
+			},
 			Costs:  []models.CostResourceRest{costResource},
 		}
 


### PR DESCRIPTION
__Short description outlining key changes/additions__
The stored e-mail address in the `CreatedBy` payments resource is sent to GovPay to store as well

__JIRA Ticket Number__
BI-6035

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__