### PR TITLE
Revert "Send email address to GovPay when creating an external resource"

### DIFF
--- a/models/gov_pay.go
+++ b/models/gov_pay.go
@@ -3,7 +3,6 @@ package models
 // OutgoingGovPayRequest is the request sent to GovPay to initiate a payment session
 type OutgoingGovPayRequest struct {
 	Amount      int    `json:"amount"`
-	Email       string `json:"email"`
 	Reference   string `json:"reference"`
 	ReturnURL   string `json:"return_url"`
 	Description string `json:"description"`

--- a/service/gov_pay.go
+++ b/service/gov_pay.go
@@ -60,7 +60,6 @@ func (gp *GovPayService) GenerateNextURLGovPay(req *http.Request, paymentResourc
 	}
 
 	govPayRequest.Amount = amountToPay
-	govPayRequest.Email = paymentResource.CreatedBy.Email
 	govPayRequest.Description = "Companies House Payment" // Hard-coded value for payment screens
 	govPayRequest.Reference = paymentResource.MetaData.ID
 	govPayRequest.ReturnURL = fmt.Sprintf("%s/callback/payments/govpay/%s", gp.PaymentService.Config.PaymentsAPIURL, paymentResource.MetaData.ID)

--- a/service/gov_pay_test.go
+++ b/service/gov_pay_test.go
@@ -162,9 +162,6 @@ func TestUnitGenerateNextURLGovPay(t *testing.T) {
 
 		paymentResource := models.PaymentResourceRest{
 			Amount: "250.567",
-			CreatedBy: models.CreatedByRest{
-				Email: "demo@demo.uk",
-			},
 			Costs:  []models.CostResourceRest{costResource},
 		}
 


### PR DESCRIPTION
Reverts companieshouse/payments.api.ch.gov.uk#134