### PR TITLE
Use DOCKER_BUILDKIT=0 flag for Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ The only external payment provider currently supported is [GOV.UK Pay](https://w
 Pull image from private CH registry by running `docker pull 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/payments.api.ch.gov.uk:latest` command or run the following steps to build image locally:
 
 1. `export SSH_PRIVATE_KEY_PASSPHRASE='[your SSH key passhprase goes here]'` (optional, set only if SSH key is passphrase protected)
-2. `docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/payments.api.ch.gov.uk:latest .`
+2. `DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/payments.api.ch.gov.uk:latest .`


### PR DESCRIPTION
__Short description outlining key changes/additions__

Docker releases >=2.4.0.0 have BuildKit enabled by default - this breaks image builds due to a known issue (https://github.com/moby/buildkit/issues/816) with BuildKit and ONBUILD COPY --from directives which we use in our runtime image.

Prefixing `docker build` commands with `DOCKER_BUILDKIT=0` fixes the issue

__JIRA Ticket Number__

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__