### PR TITLE
Create patch endpoint for updating refund status

### DIFF
--- a/fixtures/gov_pay.go
+++ b/fixtures/gov_pay.go
@@ -18,3 +18,9 @@ func GetCreateRefundGovPayRequest(amount int, amountAvailable int) *models.Creat
 		RefundAmountAvailable: amountAvailable,
 	}
 }
+
+func GetRefundStatusGovPayResponse() *models.GetRefundStatusGovPayResponse {
+	return &models.GetRefundStatusGovPayResponse{
+		Status: "success",
+	}
+}

--- a/handlers/kafka_helper.go
+++ b/handlers/kafka_helper.go
@@ -21,6 +21,7 @@ const ProducerSchemaName = "payment-processed"
 
 // paymentProcessed represents the avro schema which can be found in the chs-kafka-schemas repo
 type paymentProcessed struct {
+	Attempt          int32  `avro:"attempt"`
 	PaymentSessionID string `avro:"payment_resource_id"`
 	RefundId         string `avro:"refund_id,omitempty"`
 }
@@ -96,7 +97,7 @@ func produceKafkaMessage(paymentID string, refundID string) error {
 
 // prepareKafkaMessage is pulled out of produceKafkaMessage() to allow unit testing of non-kafka portion of code
 func prepareKafkaMessage(paymentID string, refundID string, paymentProcessedSchema avro.Schema) (*producer.Message, error) {
-	paymentProcessedMessage := paymentProcessed{PaymentSessionID: paymentID, RefundId: refundID}
+	paymentProcessedMessage := paymentProcessed{Attempt: 0, PaymentSessionID: paymentID, RefundId: refundID}
 
 	messageBytes, err := paymentProcessedSchema.Marshal(paymentProcessedMessage)
 	if err != nil {

--- a/handlers/refunds_test.go
+++ b/handlers/refunds_test.go
@@ -44,5 +44,31 @@ func TestUnitHandleCreateRefund(t *testing.T) {
 		w := httptest.NewRecorder()
 		HandleCreateRefund(w, req)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		print(w.Body)
+	})
+}
+
+func TestUnitHandleUpdateRefund(t *testing.T) {
+	cfg, _ := config.Get()
+
+	Convey("No PaymentId", t, func() {
+		req := httptest.NewRequest("PATCH", "/payments/123/refunds", nil)
+		req = mux.SetURLVars(req, map[string]string{"refundId": "123"})
+		Register(mux.NewRouter(), *cfg)
+		w := httptest.NewRecorder()
+		HandleCreateRefund(w, req)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		print(w.Body)
+	})
+
+	Convey("No RefundId", t, func() {
+		req := httptest.NewRequest("PATCH", "/payments/123/refunds/321", nil)
+		req = mux.SetURLVars(req, map[string]string{"paymentId": "123"})
+		Register(mux.NewRouter(), *cfg)
+
+		w := httptest.NewRecorder()
+		HandleCreateRefund(w, req)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+		print(w.Body)
 	})
 }

--- a/handlers/refunds_test.go
+++ b/handlers/refunds_test.go
@@ -31,7 +31,6 @@ func TestUnitHandleCreateRefund(t *testing.T) {
 		w := httptest.NewRecorder()
 		HandleCreateRefund(w, req)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-		print(w.Body)
 	})
 
 	Convey("Invalid request body", t, func() {
@@ -44,7 +43,6 @@ func TestUnitHandleCreateRefund(t *testing.T) {
 		w := httptest.NewRecorder()
 		HandleCreateRefund(w, req)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-		print(w.Body)
 	})
 }
 
@@ -58,7 +56,6 @@ func TestUnitHandleUpdateRefund(t *testing.T) {
 		w := httptest.NewRecorder()
 		HandleCreateRefund(w, req)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-		print(w.Body)
 	})
 
 	Convey("No RefundId", t, func() {
@@ -69,6 +66,5 @@ func TestUnitHandleUpdateRefund(t *testing.T) {
 		w := httptest.NewRecorder()
 		HandleCreateRefund(w, req)
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
-		print(w.Body)
 	})
 }

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -23,6 +23,7 @@ func TestUnitRegisterRoutes(t *testing.T) {
 		So(router.GetRoute("create-external-payment-journey"), ShouldNotBeNil)
 		So(router.GetRoute("handle-govpay-callback"), ShouldNotBeNil)
 		So(router.GetRoute("create-refund"), ShouldNotBeNil)
+		So(router.GetRoute("update-refund"), ShouldNotBeNil)
 	})
 }
 

--- a/mappers/refund.go
+++ b/mappers/refund.go
@@ -12,11 +12,20 @@ func MapToRefundRest(response models.CreateRefundGovPayResponse) models.RefundRe
 	}
 }
 
-func MapToRefundResponse(gpResponse models.CreateRefundGovPayResponse) models.CreateRefundResponse {
-	return models.CreateRefundResponse{
+func MapGovPayToRefundResponse(gpResponse models.CreateRefundGovPayResponse) models.RefundResponse {
+	return models.RefundResponse{
 		RefundId:        gpResponse.RefundId,
 		Amount:          gpResponse.Amount,
 		CreatedDateTime: gpResponse.CreatedDate,
 		Status:          gpResponse.Status,
+	}
+}
+
+func MapRefundToRefundResponse(refund models.RefundResourceRest) models.RefundResponse {
+	return models.RefundResponse{
+		RefundId:        refund.RefundId,
+		Amount:          refund.Amount,
+		CreatedDateTime: refund.CreatedAt,
+		Status:          refund.Status,
 	}
 }

--- a/mappers/refund.go
+++ b/mappers/refund.go
@@ -20,12 +20,3 @@ func MapGovPayToRefundResponse(gpResponse models.CreateRefundGovPayResponse) mod
 		Status:          gpResponse.Status,
 	}
 }
-
-func MapRefundToRefundResponse(refund models.RefundResourceRest) models.RefundResponse {
-	return models.RefundResponse{
-		RefundId:        refund.RefundId,
-		Amount:          refund.Amount,
-		CreatedDateTime: refund.CreatedAt,
-		Status:          refund.Status,
-	}
-}

--- a/mappers/refund_test.go
+++ b/mappers/refund_test.go
@@ -64,22 +64,3 @@ func TestUnitMapToRefundRest(t *testing.T) {
 		So(refundRest.ExternalRefundUrl, ShouldEqual, govPayResponse.Links.Self.HREF)
 	})
 }
-
-func TestUnitMapRefundToRefundResponse(t *testing.T) {
-
-	Convey("Maps successfully to refund response", t, func() {
-		refund := models.RefundResourceRest{
-			RefundId:  "123",
-			CreatedAt: "321",
-			Amount:    400,
-			Status:    "success",
-		}
-
-		refundResponse := MapRefundToRefundResponse(refund)
-
-		So(refundResponse.RefundId, ShouldEqual, refund.RefundId)
-		So(refundResponse.Amount, ShouldEqual, refund.Amount)
-		So(refundResponse.Status, ShouldEqual, refund.Status)
-		So(refundResponse.CreatedDateTime, ShouldEqual, refund.CreatedAt)
-	})
-}

--- a/mappers/refund_test.go
+++ b/mappers/refund_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestUnitMapToRefundResponse(t *testing.T) {
+func TestUnitMapGovPayToRefundResponse(t *testing.T) {
 
 	Convey("Maps successfully to refund response", t, func() {
 		govPayResponse := models.CreateRefundGovPayResponse{
@@ -26,7 +26,7 @@ func TestUnitMapToRefundResponse(t *testing.T) {
 			Status: "success",
 		}
 
-		refundResponse := MapToRefundResponse(govPayResponse)
+		refundResponse := MapGovPayToRefundResponse(govPayResponse)
 
 		So(refundResponse.RefundId, ShouldEqual, govPayResponse.RefundId)
 		So(refundResponse.Amount, ShouldEqual, govPayResponse.Amount)
@@ -62,5 +62,24 @@ func TestUnitMapToRefundRest(t *testing.T) {
 		So(refundRest.CreatedAt, ShouldEqual, govPayResponse.CreatedDate)
 		So(refundRest.Status, ShouldEqual, govPayResponse.Status)
 		So(refundRest.ExternalRefundUrl, ShouldEqual, govPayResponse.Links.Self.HREF)
+	})
+}
+
+func TestUnitMapRefundToRefundResponse(t *testing.T) {
+
+	Convey("Maps successfully to refund response", t, func() {
+		refund := models.RefundResourceRest{
+			RefundId:  "123",
+			CreatedAt: "321",
+			Amount:    400,
+			Status:    "success",
+		}
+
+		refundResponse := MapRefundToRefundResponse(refund)
+
+		So(refundResponse.RefundId, ShouldEqual, refund.RefundId)
+		So(refundResponse.Amount, ShouldEqual, refund.Amount)
+		So(refundResponse.Status, ShouldEqual, refund.Status)
+		So(refundResponse.CreatedDateTime, ShouldEqual, refund.CreatedAt)
 	})
 }

--- a/models/gov_pay.go
+++ b/models/gov_pay.go
@@ -138,3 +138,7 @@ type CreateRefundGovPayRequest struct {
 	Amount                int `json:"amount"`
 	RefundAmountAvailable int `json:"refund_amount_available"`
 }
+
+type GetRefundStatusGovPayResponse struct {
+	Status string `json:"status"`
+}

--- a/models/refund_rest.go
+++ b/models/refund_rest.go
@@ -4,7 +4,7 @@ type CreateRefundRequest struct {
 	Amount int `json:"amount"`
 }
 
-type CreateRefundResponse struct {
+type RefundResponse struct {
 	RefundId        string `json:"refund_id"`
 	CreatedDateTime string `json:"created_date_time"`
 	Amount          int    `json:"amount"`

--- a/service/mock_gov_pay.go
+++ b/service/mock_gov_pay.go
@@ -11,31 +11,31 @@ import (
 	reflect "reflect"
 )
 
-// MockProviderService is a mock of PaymentProviderService interface
-type MockProviderService struct {
+// MockPaymentProviderService is a mock of PaymentProviderService interface
+type MockPaymentProviderService struct {
 	ctrl     *gomock.Controller
-	recorder *MockProviderServiceMockRecorder
+	recorder *MockPaymentProviderServiceMockRecorder
 }
 
-// MockProviderServiceMockRecorder is the mock recorder for MockProviderService
-type MockProviderServiceMockRecorder struct {
-	mock *MockProviderService
+// MockPaymentProviderServiceMockRecorder is the mock recorder for MockPaymentProviderService
+type MockPaymentProviderServiceMockRecorder struct {
+	mock *MockPaymentProviderService
 }
 
-// NewMockProviderService creates a new mock instance
-func NewMockProviderService(ctrl *gomock.Controller) *MockProviderService {
-	mock := &MockProviderService{ctrl: ctrl}
-	mock.recorder = &MockProviderServiceMockRecorder{mock}
+// NewMockPaymentProviderService creates a new mock instance
+func NewMockPaymentProviderService(ctrl *gomock.Controller) *MockPaymentProviderService {
+	mock := &MockPaymentProviderService{ctrl: ctrl}
+	mock.recorder = &MockPaymentProviderServiceMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockProviderService) EXPECT() *MockProviderServiceMockRecorder {
+func (m *MockPaymentProviderService) EXPECT() *MockPaymentProviderServiceMockRecorder {
 	return m.recorder
 }
 
 // CheckProvider mocks base method
-func (m *MockProviderService) CheckProvider(paymentResource *models.PaymentResourceRest) (*models.StatusResponse, ResponseType, error) {
+func (m *MockPaymentProviderService) CheckProvider(paymentResource *models.PaymentResourceRest) (*models.StatusResponse, ResponseType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckProvider", paymentResource)
 	ret0, _ := ret[0].(*models.StatusResponse)
@@ -45,13 +45,13 @@ func (m *MockProviderService) CheckProvider(paymentResource *models.PaymentResou
 }
 
 // CheckProvider indicates an expected call of CheckProvider
-func (mr *MockProviderServiceMockRecorder) CheckProvider(paymentResource interface{}) *gomock.Call {
+func (mr *MockPaymentProviderServiceMockRecorder) CheckProvider(paymentResource interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckProvider", reflect.TypeOf((*MockProviderService)(nil).CheckProvider), paymentResource)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckProvider", reflect.TypeOf((*MockPaymentProviderService)(nil).CheckProvider), paymentResource)
 }
 
 // GenerateNextURLGovPay mocks base method
-func (m *MockProviderService) GenerateNextURLGovPay(req *http.Request, paymentResource *models.PaymentResourceRest) (string, ResponseType, error) {
+func (m *MockPaymentProviderService) GenerateNextURLGovPay(req *http.Request, paymentResource *models.PaymentResourceRest) (string, ResponseType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateNextURLGovPay", req, paymentResource)
 	ret0, _ := ret[0].(string)
@@ -61,13 +61,13 @@ func (m *MockProviderService) GenerateNextURLGovPay(req *http.Request, paymentRe
 }
 
 // GenerateNextURLGovPay indicates an expected call of GenerateNextURLGovPay
-func (mr *MockProviderServiceMockRecorder) GenerateNextURLGovPay(req, paymentResource interface{}) *gomock.Call {
+func (mr *MockPaymentProviderServiceMockRecorder) GenerateNextURLGovPay(req, paymentResource interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateNextURLGovPay", reflect.TypeOf((*MockProviderService)(nil).GenerateNextURLGovPay), req, paymentResource)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateNextURLGovPay", reflect.TypeOf((*MockPaymentProviderService)(nil).GenerateNextURLGovPay), req, paymentResource)
 }
 
 // GetGovPayPaymentDetails mocks base method
-func (m *MockProviderService) GetGovPayPaymentDetails(paymentResource *models.PaymentResourceRest) (*models.PaymentDetails, ResponseType, error) {
+func (m *MockPaymentProviderService) GetGovPayPaymentDetails(paymentResource *models.PaymentResourceRest) (*models.PaymentDetails, ResponseType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGovPayPaymentDetails", paymentResource)
 	ret0, _ := ret[0].(*models.PaymentDetails)
@@ -77,13 +77,13 @@ func (m *MockProviderService) GetGovPayPaymentDetails(paymentResource *models.Pa
 }
 
 // GetGovPayPaymentDetails indicates an expected call of GetGovPayPaymentDetails
-func (mr *MockProviderServiceMockRecorder) GetGovPayPaymentDetails(paymentResource interface{}) *gomock.Call {
+func (mr *MockPaymentProviderServiceMockRecorder) GetGovPayPaymentDetails(paymentResource interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGovPayPaymentDetails", reflect.TypeOf((*MockProviderService)(nil).GetGovPayPaymentDetails), paymentResource)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGovPayPaymentDetails", reflect.TypeOf((*MockPaymentProviderService)(nil).GetGovPayPaymentDetails), paymentResource)
 }
 
 // GetGovPayRefundSummary mocks base method
-func (m *MockProviderService) GetGovPayRefundSummary(req *http.Request, id string) (*models.PaymentResourceRest, *models.RefundSummary, ResponseType, error) {
+func (m *MockPaymentProviderService) GetGovPayRefundSummary(req *http.Request, id string) (*models.PaymentResourceRest, *models.RefundSummary, ResponseType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGovPayRefundSummary", req, id)
 	ret0, _ := ret[0].(*models.PaymentResourceRest)
@@ -94,13 +94,29 @@ func (m *MockProviderService) GetGovPayRefundSummary(req *http.Request, id strin
 }
 
 // GetGovPayRefundSummary indicates an expected call of GetGovPayRefundSummary
-func (mr *MockProviderServiceMockRecorder) GetGovPayRefundSummary(req, id interface{}) *gomock.Call {
+func (mr *MockPaymentProviderServiceMockRecorder) GetGovPayRefundSummary(req, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGovPayRefundSummary", reflect.TypeOf((*MockProviderService)(nil).GetGovPayRefundSummary), req, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGovPayRefundSummary", reflect.TypeOf((*MockPaymentProviderService)(nil).GetGovPayRefundSummary), req, id)
+}
+
+// GetGovPayRefundStatus mocks base method
+func (m *MockPaymentProviderService) GetGovPayRefundStatus(paymentResource *models.PaymentResourceRest, refundId string) (*models.GetRefundStatusGovPayResponse, ResponseType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGovPayRefundStatus", paymentResource, refundId)
+	ret0, _ := ret[0].(*models.GetRefundStatusGovPayResponse)
+	ret1, _ := ret[1].(ResponseType)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetGovPayRefundStatus indicates an expected call of GetGovPayRefundStatus
+func (mr *MockPaymentProviderServiceMockRecorder) GetGovPayRefundStatus(paymentResource, refundId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGovPayRefundStatus", reflect.TypeOf((*MockPaymentProviderService)(nil).GetGovPayRefundStatus), paymentResource, refundId)
 }
 
 // CreateRefund mocks base method
-func (m *MockProviderService) CreateRefund(paymentResource *models.PaymentResourceRest, refundRequest *models.CreateRefundGovPayRequest) (*models.CreateRefundGovPayResponse, ResponseType, error) {
+func (m *MockPaymentProviderService) CreateRefund(paymentResource *models.PaymentResourceRest, refundRequest *models.CreateRefundGovPayRequest) (*models.CreateRefundGovPayResponse, ResponseType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRefund", paymentResource, refundRequest)
 	ret0, _ := ret[0].(*models.CreateRefundGovPayResponse)
@@ -110,7 +126,7 @@ func (m *MockProviderService) CreateRefund(paymentResource *models.PaymentResour
 }
 
 // CreateRefund indicates an expected call of CreateRefund
-func (mr *MockProviderServiceMockRecorder) CreateRefund(paymentResource, refundRequest interface{}) *gomock.Call {
+func (mr *MockPaymentProviderServiceMockRecorder) CreateRefund(paymentResource, refundRequest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRefund", reflect.TypeOf((*MockProviderService)(nil).CreateRefund), paymentResource, refundRequest)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRefund", reflect.TypeOf((*MockPaymentProviderService)(nil).CreateRefund), paymentResource, refundRequest)
 }

--- a/service/refund.go
+++ b/service/refund.go
@@ -76,7 +76,7 @@ func (service *RefundService) CreateRefund(req *http.Request, id string, createR
 }
 
 // UpdateRefund checks refund status in GovPay and if status is successful saves it to payment object in mongo
-func (service *RefundService) UpdateRefund(req *http.Request, paymentId string, refundId string) (*models.RefundResponse, ResponseType, error) {
+func (service *RefundService) UpdateRefund(req *http.Request, paymentId string, refundId string) (*models.RefundResourceRest, ResponseType, error) {
 	paymentSession, response, err := service.PaymentService.GetPaymentSession(req, paymentId)
 	if err != nil {
 		err = fmt.Errorf("error getting payment resource: [%v]", err)
@@ -119,9 +119,7 @@ func (service *RefundService) UpdateRefund(req *http.Request, paymentId string, 
 		}
 	}
 
-	refundResponse := mappers.MapRefundToRefundResponse(paymentSession.Refunds[index])
-
-	return &refundResponse, Success, nil
+	return &paymentSession.Refunds[index], Success, nil
 }
 
 func getRefundIndex(refunds []models.RefundResourceRest, refundId string) (int, error) {

--- a/service/refund.go
+++ b/service/refund.go
@@ -105,18 +105,15 @@ func (service *RefundService) UpdateRefund(req *http.Request, paymentId string, 
 		return nil, response, err
 	}
 
-	if govPayStatusResponse.Status == RefundsStatusSuccess {
+	paymentSession.Refunds[index].Status = govPayStatusResponse.Status
 
-		paymentSession.Refunds[index].Status = RefundsStatusSuccess
+	paymentResourceUpdate := transformers.PaymentTransformer{}.TransformToDB(*paymentSession)
 
-		paymentResourceUpdate := transformers.PaymentTransformer{}.TransformToDB(*paymentSession)
-
-		err = service.DAO.PatchPaymentResource(paymentId, &paymentResourceUpdate)
-		if err != nil {
-			err = fmt.Errorf("error patching payment session to database: [%v]", err)
-			log.Error(err)
-			return nil, Error, err
-		}
+	err = service.DAO.PatchPaymentResource(paymentId, &paymentResourceUpdate)
+	if err != nil {
+		err = fmt.Errorf("error patching payment session to database: [%v]", err)
+		log.Error(err)
+		return nil, Error, err
 	}
 
 	return &paymentSession.Refunds[index], Success, nil

--- a/service/refund.go
+++ b/service/refund.go
@@ -12,23 +12,25 @@ import (
 	"net/http"
 )
 
-type RefundStatus string
-
 const (
-	RefundPending     = "pending"
-	RefundUnavailable = "unavailable"
-	RefundAvailable   = "available"
-	RefundFull        = "full"
+	RefundPending          = "pending"
+	RefundUnavailable      = "unavailable"
+	RefundAvailable        = "available"
+	RefundFull             = "full"
+	RefundsStatusSuccess   = "success"
+	RefundsStatusSubmitted = "submitted"
+	RefundsStatusError     = "error"
 )
 
 type RefundService struct {
-	GovPayService PaymentProviderService
-	DAO           dao.DAO
-	Config        config.Config
+	GovPayService  PaymentProviderService
+	PaymentService *PaymentService
+	DAO            dao.DAO
+	Config         config.Config
 }
 
 // CreateRefund creates refund in GovPay and saves refund information to payment object in mongo
-func (service *RefundService) CreateRefund(req *http.Request, id string, createRefundResource models.CreateRefundRequest) (*models.PaymentResourceRest, *models.CreateRefundResponse, ResponseType, error) {
+func (service *RefundService) CreateRefund(req *http.Request, id string, createRefundResource models.CreateRefundRequest) (*models.PaymentResourceRest, *models.RefundResponse, ResponseType, error) {
 
 	// Get RefundSummary from GovPay to check the available amount
 	paymentSession, refundSummary, response, err := service.GovPayService.GetGovPayRefundSummary(req, id)
@@ -56,7 +58,7 @@ func (service *RefundService) CreateRefund(req *http.Request, id string, createR
 		return nil, nil, response, err
 	}
 
-	refundResource := mappers.MapToRefundResponse(*refund)
+	refundResource := mappers.MapGovPayToRefundResponse(*refund)
 
 	// Add refund information to payment session
 	paymentSession.Refunds = append(paymentSession.Refunds, mappers.MapToRefundRest(*refund))
@@ -71,4 +73,62 @@ func (service *RefundService) CreateRefund(req *http.Request, id string, createR
 	}
 
 	return paymentSession, &refundResource, Success, nil
+}
+
+// UpdateRefund checks refund status in GovPay and if status is successful saves it to payment object in mongo
+func (service *RefundService) UpdateRefund(req *http.Request, paymentId string, refundId string) (*models.RefundResponse, ResponseType, error) {
+	paymentSession, response, err := service.PaymentService.GetPaymentSession(req, paymentId)
+	if err != nil {
+		err = fmt.Errorf("error getting payment resource: [%v]", err)
+		log.ErrorR(req, err)
+		return nil, response, err
+	}
+
+	if response == NotFound {
+		err = fmt.Errorf("error getting payment resource")
+		log.ErrorR(req, err)
+
+		return nil, NotFound, err
+	}
+
+	index, err := getRefundIndex(paymentSession.Refunds, refundId)
+
+	if err != nil {
+		log.ErrorR(req, err)
+		return nil, NotFound, err
+	}
+	// Get RefundStatus from GovPay to check the status of the refund
+	govPayStatusResponse, response, err := service.GovPayService.GetGovPayRefundStatus(paymentSession, refundId)
+	if err != nil {
+		err = fmt.Errorf("error getting refund status from govpay: [%v]", err)
+		log.ErrorR(req, err)
+		return nil, response, err
+	}
+
+	if govPayStatusResponse.Status == RefundsStatusSuccess {
+
+		paymentSession.Refunds[index].Status = RefundsStatusSuccess
+
+		paymentResourceUpdate := transformers.PaymentTransformer{}.TransformToDB(*paymentSession)
+
+		err = service.DAO.PatchPaymentResource(paymentId, &paymentResourceUpdate)
+		if err != nil {
+			err = fmt.Errorf("error patching payment session to database: [%v]", err)
+			log.Error(err)
+			return nil, Error, err
+		}
+	}
+
+	refundResponse := mappers.MapRefundToRefundResponse(paymentSession.Refunds[index])
+
+	return &refundResponse, Success, nil
+}
+
+func getRefundIndex(refunds []models.RefundResourceRest, refundId string) (int, error) {
+	for i, ref := range refunds {
+		if ref.RefundId == refundId {
+			return i, nil
+		}
+	}
+	return -1, errors.New("refund id not found in payment refunds")
 }

--- a/service/refund_test.go
+++ b/service/refund_test.go
@@ -7,8 +7,11 @@ import (
 	"github.com/companieshouse/payments.api.ch.gov.uk/fixtures"
 	"github.com/companieshouse/payments.api.ch.gov.uk/models"
 	"github.com/golang/mock/gomock"
+	"github.com/jarcoal/httpmock"
+	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -19,7 +22,7 @@ func TestUnitCreateRefund(t *testing.T) {
 	cfg, _ := config.Get()
 
 	mockDao := dao.NewMockDAO(mockCtrl)
-	mockGovPayService := NewMockProviderService(mockCtrl)
+	mockGovPayService := NewMockPaymentProviderService(mockCtrl)
 
 	service := RefundService{
 		GovPayService: mockGovPayService,
@@ -112,6 +115,197 @@ func TestUnitCreateRefund(t *testing.T) {
 		So(paymentSession, ShouldNotBeNil)
 		So(refund, ShouldNotBeNil)
 		So(status, ShouldEqual, Success)
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestUnitUpdateRefund(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	cfg, _ := config.Get()
+
+	mockDao := dao.NewMockDAO(mockCtrl)
+	mockGovPayService := NewMockPaymentProviderService(mockCtrl)
+	mockPaymentService := createMockPaymentService(mockDao, cfg)
+
+	service := RefundService{
+		GovPayService:  mockGovPayService,
+		PaymentService: &mockPaymentService,
+		DAO:            mockDao,
+		Config:         *cfg,
+	}
+
+	req := httptest.NewRequest("PATCH", "/test", nil)
+	paymentId := "123"
+	refundId := "321"
+
+	Convey("Error when getting payment session", t, func() {
+		mockDao.EXPECT().GetPaymentResource(paymentId).Return(&models.PaymentResourceDB{}, fmt.Errorf("error"))
+
+		refund, status, err := service.UpdateRefund(req, paymentId, refundId)
+
+		So(refund, ShouldBeNil)
+		So(status, ShouldEqual, Error)
+		So(err.Error(), ShouldEqual, "error getting payment resource: [error getting payment resource from db: [error]]")
+	})
+
+	Convey("Error getting payment resource from db", t, func() {
+		mockDao.EXPECT().GetPaymentResource(paymentId).Return(&models.PaymentResourceDB{}, fmt.Errorf("error"))
+
+		refund, status, err := service.UpdateRefund(req, paymentId, refundId)
+
+		So(status, ShouldEqual, Error)
+		So(refund, ShouldBeNil)
+		So(err.Error(), ShouldEqual, "error getting payment resource: [error getting payment resource from db: [error]]")
+	})
+
+	Convey("Payment resource not found in db", t, func() {
+		mockDao.EXPECT().GetPaymentResource(paymentId).Return(nil, nil)
+
+		refund, status, err := service.UpdateRefund(req, paymentId, refundId)
+
+		So(status, ShouldEqual, NotFound)
+		So(refund, ShouldBeNil)
+		So(err.Error(), ShouldEqual, "error getting payment resource")
+	})
+
+	Convey("Refund id not present in payment session", t, func() {
+		mockDao.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResourceDB{ID: "1234", ExternalPaymentStatusURI: "http://external_uri", Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}}}, nil)
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
+		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+
+		govPayState := models.State{Status: "success", Finished: true}
+		incomingGovPayResponse := models.IncomingGovPayResponse{CardBrand: "Visa", PaymentID: "1234", CreatedDate: "2016-01-21T17:15:000Z", State: govPayState, RefundSummary: models.RefundSummary{
+			Status:          "available",
+			AmountAvailable: 0,
+			AmountSubmitted: 0,
+		}}
+
+		govPayResponse, _ := httpmock.NewJsonResponder(http.StatusOK, incomingGovPayResponse)
+		httpmock.RegisterResponder("GET", "http://external_uri", govPayResponse)
+
+		refund, status, err := service.UpdateRefund(req, paymentId, refundId)
+
+		So(status, ShouldEqual, NotFound)
+		So(refund, ShouldBeNil)
+		So(err.Error(), ShouldEqual, "refund id not found in payment refunds")
+	})
+
+	Convey("Error getting response from GovPay ", t, func() {
+		now := time.Now()
+		mockGovPayService.EXPECT().GetGovPayRefundStatus(gomock.Any(), refundId).Return(nil, Error, fmt.Errorf("error generating request for GovPay"))
+		mockDao.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResourceDB{ID: "1234", ExternalPaymentStatusURI: "http://external_uri", Refunds: []models.RefundResourceDB{
+			{
+				RefundId:          refundId,
+				CreatedAt:         now.String(),
+				Amount:            400,
+				Status:            "success",
+				ExternalRefundUrl: "external",
+			},
+		}, Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}}}, nil)
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
+		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+
+		govPayState := models.State{Status: "success", Finished: true}
+		incomingGovPayResponse := models.IncomingGovPayResponse{CardBrand: "Visa", PaymentID: "1234", CreatedDate: "2016-01-21T17:15:000Z", State: govPayState, RefundSummary: models.RefundSummary{
+			Status:          "full",
+			AmountAvailable: 0,
+			AmountSubmitted: 0,
+		}}
+
+		govPayResponse, _ := httpmock.NewJsonResponder(http.StatusOK, incomingGovPayResponse)
+		httpmock.RegisterResponder("GET", "http://external_uri", govPayResponse)
+
+		refund, status, err := service.UpdateRefund(req, paymentId, refundId)
+
+		So(status, ShouldEqual, Error)
+		So(refund, ShouldBeNil)
+		So(err.Error(), ShouldEqual, "error getting refund status from govpay: [error generating request for GovPay]")
+	})
+
+	Convey("Does not patch resource ", t, func() {
+		now := time.Now()
+		mockGovPayService.EXPECT().GetGovPayRefundStatus(gomock.Any(), refundId).Return(&models.GetRefundStatusGovPayResponse{Status: RefundsStatusSubmitted}, Success, nil)
+		mockDao.EXPECT().PatchPaymentResource(paymentId, gomock.Any()).Times(0)
+		mockDao.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResourceDB{ID: "1234", ExternalPaymentStatusURI: "http://external_uri", Refunds: []models.RefundResourceDB{
+			{
+				RefundId:          refundId,
+				CreatedAt:         now.String(),
+				Amount:            400,
+				Status:            "submitted",
+				ExternalRefundUrl: "external",
+			},
+		}, Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}}}, nil)
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
+		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+
+		govPayState := models.State{Status: "success", Finished: true}
+		incomingGovPayResponse := models.IncomingGovPayResponse{CardBrand: "Visa", PaymentID: "1234", CreatedDate: "2016-01-21T17:15:000Z", State: govPayState, RefundSummary: models.RefundSummary{
+			Status:          "full",
+			AmountAvailable: 0,
+			AmountSubmitted: 0,
+		}}
+
+		govPayResponse, _ := httpmock.NewJsonResponder(http.StatusOK, incomingGovPayResponse)
+		httpmock.RegisterResponder("GET", "http://external_uri", govPayResponse)
+
+		refund, status, err := service.UpdateRefund(req, paymentId, refundId)
+
+		So(status, ShouldEqual, Success)
+		So(refund.Status, ShouldEqual, RefundsStatusSubmitted)
+		So(err, ShouldBeNil)
+	})
+
+	FocusConvey("Patches resource ", t, func() {
+		now := time.Now()
+		var capturedSession *models.PaymentResourceDB
+		mockGovPayService.EXPECT().GetGovPayRefundStatus(gomock.Any(), refundId).Return(&models.GetRefundStatusGovPayResponse{Status: RefundsStatusSuccess}, Success, nil)
+		mockDao.EXPECT().PatchPaymentResource(paymentId, gomock.Any()).Do(func(paymentId string, session *models.PaymentResourceDB) {
+			capturedSession = session
+		})
+		mockDao.EXPECT().GetPaymentResource(gomock.Any()).Return(&models.PaymentResourceDB{ID: "1234", ExternalPaymentStatusURI: "http://external_uri", Refunds: []models.RefundResourceDB{
+			{
+				RefundId:          refundId,
+				CreatedAt:         now.String(),
+				Amount:            400,
+				Status:            "submitted",
+				ExternalRefundUrl: "external",
+			},
+		}, Data: models.PaymentResourceDataDB{Amount: "10.00", Links: models.PaymentLinksDB{Resource: "http://dummy-resource"}}}, nil)
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		jsonResponse, _ := httpmock.NewJsonResponder(200, defaultCosts)
+		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+
+		govPayState := models.State{Status: "success", Finished: true}
+		incomingGovPayResponse := models.IncomingGovPayResponse{CardBrand: "Visa", PaymentID: "1234", CreatedDate: "2016-01-21T17:15:000Z", State: govPayState, RefundSummary: models.RefundSummary{
+			Status:          "full",
+			AmountAvailable: 0,
+			AmountSubmitted: 0,
+		}}
+
+		govPayResponse, _ := httpmock.NewJsonResponder(http.StatusOK, incomingGovPayResponse)
+		httpmock.RegisterResponder("GET", "http://external_uri", govPayResponse)
+
+		refund, status, err := service.UpdateRefund(req, paymentId, refundId)
+
+		So(capturedSession.Refunds[0].Status, ShouldEqual, RefundsStatusSuccess)
+		So(status, ShouldEqual, Success)
+		So(refund.Status, ShouldEqual, RefundsStatusSuccess)
 		So(err, ShouldBeNil)
 	})
 }


### PR DESCRIPTION
Create a new refund PATCH endpoint that will sync the refund status in payments MongoDB with the status of GovPay refund. GovPay refund status is updated asynchronously and this fix is needed for payment-reconciliation-consumer to properly reconcile the refund.

https://companieshouse.atlassian.net/browse/BI-6366

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__