### PR TITLE
Log the status code when getCosts receives a non-200 status

### DIFF
--- a/service/payment.go
+++ b/service/payment.go
@@ -260,7 +260,7 @@ func getCosts(resource string, cfg *config.Config) (*models.CostsRest, ResponseT
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		err = errors.New("error getting Cost Resource")
+		err = errors.New("error getting Cost Resource - status code: [%v]", resp.StatusCode)
 		log.ErrorR(resourceReq, err)
 		return nil, InvalidData, err
 	}


### PR DESCRIPTION
This change logs the HTTP status code when a non-200 status code is returned

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change