### PR TITLE
Update tiltfile to add live_update

### DIFF
--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -4,12 +4,16 @@ custom_build(
   deps = [
     './',
   ],
+  live_update = [
+    sync('./payments.api.ch.gov.uk', '/app/app'),
+    restart_container(),
+  ],
   ignore = [
     'LICENSE',
     'Makefile',
     'Readme',
     '.github',
     '.gitignore',
-    '.dockerignore'
+    '.dockerignore',
   ]
 )


### PR DESCRIPTION
Adds a live update step which targets only the built executable for the Payments API - useful when you want finer control over the build process but requires modifying the `deps` array