### PR TITLE
Separate GET endpoint into its own router

### DIFF
--- a/handlers/register.go
+++ b/handlers/register.go
@@ -61,11 +61,11 @@ func Register(mainRouter *mux.Router, cfg config.Config) {
 	// per-subrouter middleware.
 
 	// create-payment endpoint should not be intercepted by the paymentauth interceptor, so needs to be it's own subrouter
-	rootPaymentRouter := mainRouter.PathPrefix("/payments").Subrouter()
-	rootPaymentRouter.HandleFunc("", HandleCreatePaymentSession).Methods("POST").Name("create-payment")
+	createPaymentRouter := mainRouter.PathPrefix("/payments").Subrouter()
+	createPaymentRouter.HandleFunc("", HandleCreatePaymentSession).Methods("POST").Name("create-payment")
 
 	// get-payment endpoint needs payment and user auth, so needs to be it's own subrouter
-	getPaymentRouter := rootPaymentRouter.PathPrefix("/{payment_id}").Subrouter()
+	getPaymentRouter := mainRouter.PathPrefix("/{payment_id}").Subrouter()
 	getPaymentRouter.HandleFunc("", HandleGetPaymentSession).Methods("GET").Name("get-payment")
 
 	// payment-details endpoint needs it's own interceptor
@@ -92,8 +92,8 @@ func Register(mainRouter *mux.Router, cfg config.Config) {
 	callbackRouter.HandleFunc("/payments/govpay/{payment_id}", HandleGovPayCallback).Methods("GET").Name("handle-govpay-callback")
 
 	// Set middleware for subrouters
-	rootPaymentRouter.Use(log.Handler, interceptors.Oauth2OrPaymentPrivilegesIntercept, interceptors.UserPaymentAuthenticationIntercept)
-	getPaymentRouter.Use(pa.PaymentAuthenticationIntercept)
+	createPaymentRouter.Use(log.Handler, interceptors.Oauth2OrPaymentPrivilegesIntercept, interceptors.UserPaymentAuthenticationIntercept)
+	getPaymentRouter.Use(interceptors.UserPaymentAuthenticationIntercept, pa.PaymentAuthenticationIntercept)
 	paymentDetailsRouter.Use(log.Handler, interceptors.InternalOrPaymentPrivilegesIntercept, pa.PaymentAuthenticationIntercept)
 	createRefundRouter.Use(log.Handler, authentication.ElevatedPrivilegesInterceptor)
 	updateRefundRouter.Use(log.Handler, authentication.ElevatedPrivilegesInterceptor)

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -20,6 +20,7 @@ func TestUnitRegisterRoutes(t *testing.T) {
 		So(router.GetRoute("get-healthcheck"), ShouldNotBeNil)
 		So(router.GetRoute("create-payment"), ShouldNotBeNil)
 		So(router.GetRoute("get-payment"), ShouldNotBeNil)
+		So(router.GetRoute("get-payment-details"), ShouldNotBeNil)
 		So(router.GetRoute("patch-payment"), ShouldNotBeNil)
 		So(router.GetRoute("create-external-payment-journey"), ShouldNotBeNil)
 		So(router.GetRoute("handle-govpay-callback"), ShouldNotBeNil)


### PR DESCRIPTION
Separate GET endpoint into its own router
to prevent incorrect authorisation being executed in the interceptors

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__