### PR TITLE
Allow Legacy Users (Api Key users) to integrate with the payment service

### DIFF
--- a/handlers/callback_test.go
+++ b/handlers/callback_test.go
@@ -21,7 +21,7 @@ import (
 var defaultCost = models.CostResourceRest{
 	Amount:                  "10",
 	AvailablePaymentMethods: []string{"GovPay"},
-	ClassOfPayment:          []string{"class"},
+	ClassOfPayment:          []string{"data-maintenance"},
 	Description:             "desc",
 	DescriptionIdentifier:   "identifier",
 	ProductType:             "productType",
@@ -62,6 +62,7 @@ func TestUnitHandleGovPayCallback(t *testing.T) {
 	defer mockCtrl.Finish()
 	cfg, _ := config.Get()
 	cfg.DomainAllowList = "http://dummy-url"
+
 	Convey("Payment ID not supplied", t, func() {
 		req := httptest.NewRequest("GET", "/test", nil)
 		w := httptest.NewRecorder()

--- a/interceptors/payment_authentication_test.go
+++ b/interceptors/payment_authentication_test.go
@@ -19,11 +19,12 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const resourceURL = "http://dummy-resource"
+
 func GetTestHandler() http.HandlerFunc {
-	fn := func(w http.ResponseWriter, req *http.Request) {
+	return func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}
-	return http.HandlerFunc(fn)
 }
 
 var defaultCostRest = models.CostResourceRest{
@@ -67,7 +68,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	cfg, _ := config.Get()
-	cfg.DomainAllowList = "http://dummy-resource"
+	cfg.DomainAllowList = resourceURL
 
 	Convey("No payment ID in request", t, func() {
 		path := fmt.Sprintf("/payments/")
@@ -155,7 +156,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		costArray := []models.CostResourceRest{defaultCostRest}
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, costArray)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", resourceURL, jsonResponse)
 
 		test := paymentAuthenticationInterceptor.PaymentAuthenticationIntercept(GetTestHandler())
 		test.ServeHTTP(w, req.WithContext(ctx))
@@ -187,7 +188,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 		costArray := []models.CostResourceRest{defaultCostRest}
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, costArray)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", resourceURL, jsonResponse)
 
 		test := paymentAuthenticationInterceptor.PaymentAuthenticationIntercept(GetTestHandler())
 		test.ServeHTTP(w, req.WithContext(ctx))
@@ -218,7 +219,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 				Data: models.PaymentResourceDataDB{
 					Amount:    "20.00",
 					CreatedBy: models.CreatedByDB{ID: "identity"},
-					Links:     models.PaymentLinksDB{Resource: "http://dummy-resource"},
+					Links:     models.PaymentLinksDB{Resource: resourceURL},
 				},
 			},
 			nil,
@@ -228,7 +229,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", resourceURL, jsonResponse)
 
 		test := paymentAuthenticationInterceptor.PaymentAuthenticationIntercept(GetTestHandler())
 		test.ServeHTTP(w, req.WithContext(ctx))
@@ -259,7 +260,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 				Data: models.PaymentResourceDataDB{
 					Amount:    "10.00",
 					CreatedBy: models.CreatedByDB{ID: "identity"},
-					Links:     models.PaymentLinksDB{Resource: "http://dummy-resource"},
+					Links:     models.PaymentLinksDB{Resource: resourceURL},
 				},
 			},
 			nil,
@@ -269,7 +270,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", resourceURL, jsonResponse)
 
 		test := paymentAuthenticationInterceptor.PaymentAuthenticationIntercept(GetTestHandler())
 		test.ServeHTTP(w, req.WithContext(ctx))
@@ -300,7 +301,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 				Data: models.PaymentResourceDataDB{
 					Amount:    "10.00",
 					CreatedBy: models.CreatedByDB{ID: "adminidentity"},
-					Links:     models.PaymentLinksDB{Resource: "http://dummy-resource"},
+					Links:     models.PaymentLinksDB{Resource: resourceURL},
 				},
 			},
 			nil,
@@ -310,7 +311,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", resourceURL, jsonResponse)
 
 		test := paymentAuthenticationInterceptor.PaymentAuthenticationIntercept(GetTestHandler())
 		test.ServeHTTP(w, req.WithContext(ctx))
@@ -341,7 +342,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 				Data: models.PaymentResourceDataDB{
 					Amount:    "10.00",
 					CreatedBy: models.CreatedByDB{ID: "adminidentity"},
-					Links:     models.PaymentLinksDB{Resource: "http://dummy-resource"},
+					Links:     models.PaymentLinksDB{Resource: resourceURL},
 				},
 			},
 			nil,
@@ -351,7 +352,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", resourceURL, jsonResponse)
 
 		test := paymentAuthenticationInterceptor.PaymentAuthenticationIntercept(GetTestHandler())
 		test.ServeHTTP(w, req.WithContext(ctx))
@@ -381,7 +382,7 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 				Data: models.PaymentResourceDataDB{
 					Amount:    "10.00",
 					CreatedBy: models.CreatedByDB{ID: "identity"},
-					Links:     models.PaymentLinksDB{Resource: "http://dummy-resource"},
+					Links:     models.PaymentLinksDB{Resource: resourceURL},
 				},
 			},
 			nil,
@@ -391,7 +392,47 @@ func TestUnitUserPaymentInterceptor(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, defaultCosts)
-		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
+		httpmock.RegisterResponder("GET", resourceURL, jsonResponse)
+
+		test := paymentAuthenticationInterceptor.PaymentAuthenticationIntercept(GetTestHandler())
+		test.ServeHTTP(w, req.WithContext(ctx))
+		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+
+	Convey("Happy path where user has payment privileges key accessing a non-creator resource", t, func() {
+		path := fmt.Sprintf("/payments/%s", "1234")
+		req, err := http.NewRequest("GET", path, nil)
+		So(err, ShouldBeNil)
+		req = mux.SetURLVars(req, map[string]string{"payment_id": "1234"})
+		req.Header.Set("Eric-Identity", "identity")
+		req.Header.Set("Eric-Identity-Type", "key")
+		req.Header.Set("ERIC-Authorised-User", "test@test.com;test;user")
+		req.Header.Set("ERIC-Authorised-Key-Privileges", "payment")
+		authUserDetails := authentication.AuthUserDetails{
+			ID: "api-key-user",
+		}
+		ctx := context.WithValue(req.Context(), authentication.ContextKeyUserDetails, authUserDetails)
+		mockDAO := dao.NewMockDAO(mockCtrl)
+		mockPaymentService := createMockPaymentService(mockDAO, cfg)
+		paymentAuthenticationInterceptor := createPaymentAuthenticationInterceptorWithMockService(&mockPaymentService)
+
+		mockDAO.EXPECT().GetPaymentResource("1234").Return(
+			&models.PaymentResourceDB{
+				ID: "1234",
+				Data: models.PaymentResourceDataDB{
+					Amount:    "10.00",
+					CreatedBy: models.CreatedByDB{ID: "identity"},
+					Links:     models.PaymentLinksDB{Resource: resourceURL},
+				},
+			},
+			nil,
+		)
+
+		w := httptest.NewRecorder()
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		jsonResponse, _ := httpmock.NewJsonResponder(http.StatusOK, defaultCosts)
+		httpmock.RegisterResponder("GET", resourceURL, jsonResponse)
 
 		test := paymentAuthenticationInterceptor.PaymentAuthenticationIntercept(GetTestHandler())
 		test.ServeHTTP(w, req.WithContext(ctx))

--- a/service/payment.go
+++ b/service/payment.go
@@ -126,6 +126,12 @@ func (service *PaymentService) CreatePaymentSession(req *http.Request, createRes
 	paymentResourceID := generateID()
 
 	journeyURL := service.Config.PaymentsWebURL + "/payments/" + paymentResourceID + "/pay"
+
+	// If auth is API Key, add suffix to journey URL
+	if authentication.GetAuthorisedIdentityType(req) == authentication.APIKeyIdentityType {
+		journeyURL += "/api-key"
+	}
+
 	paymentResourceRest.Links = models.PaymentLinksRest{
 		Journey:  journeyURL,
 		Resource: createResource.Resource,

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -20,7 +20,7 @@ import (
 var defaultCost = models.CostResourceRest{
 	Amount:                  "10",
 	AvailablePaymentMethods: []string{"GovPay"},
-	ClassOfPayment:          []string{"class"},
+	ClassOfPayment:          []string{"data-maintenance"},
 	Description:             "desc",
 	DescriptionIdentifier:   "identifier",
 	ProductType:             "productType",
@@ -500,7 +500,7 @@ func TestUnitGetPayment(t *testing.T) {
 				{
 					Amount:                  "10",
 					AvailablePaymentMethods: []string{"GovPay"},
-					ClassOfPayment:          []string{"class"},
+					ClassOfPayment:          []string{"data-maintenance"},
 					Description:             "desc",
 					DescriptionIdentifier:   "identifier",
 					ProductType:             "productType",
@@ -548,7 +548,7 @@ func TestUnitGetPayment(t *testing.T) {
 				{
 					Amount:                  "10",
 					AvailablePaymentMethods: []string{"GovPay"},
-					ClassOfPayment:          []string{"class"},
+					ClassOfPayment:          []string{"data-maintenance"},
 					Description:             "desc",
 					DescriptionIdentifier:   "identifier",
 					ProductType:             "productType",
@@ -556,7 +556,7 @@ func TestUnitGetPayment(t *testing.T) {
 				{
 					Amount:                  "10",
 					AvailablePaymentMethods: []string{"GovPay"},
-					ClassOfPayment:          []string{"class"},
+					ClassOfPayment:          []string{"data-maintenance"},
 					Description:             "desc",
 					DescriptionIdentifier:   "identifier",
 					ProductType:             "productType",


### PR DESCRIPTION
Linked to https://github.com/companieshouse/sdk-manager-java/pull/39 and https://github.com/companieshouse/payments.web.ch.gov.uk/pull/69

This change updates the payments api to accommodate legacy users:

- return updated url ending in 'api-key' for api key users

Info can be found here: https://companieshouse.atlassian.net/wiki/spaces/CPS/pages/3387654740/Opening+up+the+Payment+Service+to+Legacy+services

### Type of change

* [ ] Bug fix
* [ x] New feature
* [x ] Breaking change

### Pull request checklist

* [x ] I have added unit tests for new code that I have added
* [ x] I have added/updated functional tests where appropriate
* [x ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__