### PR TITLE
Change GovPay payment method to credit-card

### DIFF
--- a/handlers/callback.go
+++ b/handlers/callback.go
@@ -67,7 +67,7 @@ func HandleGovPayCallback(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Ensure payment method matches endpoint
-	if paymentSession.PaymentMethod != "GovPay" {
+	if paymentSession.PaymentMethod != "credit-card" {
 		log.ErrorR(req, fmt.Errorf("payment method, [%s], for resource [%s] not recognised", paymentSession.PaymentMethod, id))
 		w.WriteHeader(http.StatusPreconditionFailed)
 		return

--- a/handlers/callback_test.go
+++ b/handlers/callback_test.go
@@ -20,7 +20,7 @@ import (
 
 var defaultCost = models.CostResourceRest{
 	Amount:                  "10",
-	AvailablePaymentMethods: []string{"GovPay"},
+	AvailablePaymentMethods: []string{"credit-card"},
 	ClassOfPayment:          []string{"data-maintenance"},
 	Description:             "desc",
 	DescriptionIdentifier:   "identifier",
@@ -176,13 +176,13 @@ func TestUnitHandleGovPayCallback(t *testing.T) {
 		So(w.Code, ShouldEqual, http.StatusPreconditionFailed)
 	})
 
-	Convey("Error getting payment status from GovPay", t, func() {
+	Convey("Error getting payment status from credit-card", t, func() {
 		mock := dao.NewMockDAO(mockCtrl)
 		paymentService = createMockPaymentService(mock, cfg)
 		paymentSession := models.PaymentResourceDB{
 			Data: models.PaymentResourceDataDB{
 				Amount:        "10.00",
-				PaymentMethod: "GovPay",
+				PaymentMethod: "credit-card",
 				Links: models.PaymentLinksDB{
 					Resource: "http://dummy-url",
 				},
@@ -209,7 +209,7 @@ func TestUnitHandleGovPayCallback(t *testing.T) {
 		paymentSession := models.PaymentResourceDB{
 			Data: models.PaymentResourceDataDB{
 				Amount:        "10.00",
-				PaymentMethod: "GovPay",
+				PaymentMethod: "credit-card",
 				Links: models.PaymentLinksDB{
 					Resource: "http://dummy-url",
 				},
@@ -240,7 +240,7 @@ func TestUnitHandleGovPayCallback(t *testing.T) {
 		paymentSession := models.PaymentResourceDB{
 			Data: models.PaymentResourceDataDB{
 				Amount:        "10.00",
-				PaymentMethod: "GovPay",
+				PaymentMethod: "credit-card",
 				Links: models.PaymentLinksDB{
 					Resource: "http://dummy-url",
 				},
@@ -273,7 +273,7 @@ func TestUnitHandleGovPayCallback(t *testing.T) {
 		paymentSession := models.PaymentResourceDB{
 			Data: models.PaymentResourceDataDB{
 				Amount:        "10.00",
-				PaymentMethod: "GovPay",
+				PaymentMethod: "credit-card",
 				Links: models.PaymentLinksDB{
 					Resource: "http://dummy-url",
 				},

--- a/service/external_paysession.go
+++ b/service/external_paysession.go
@@ -24,7 +24,7 @@ func (service *PaymentService) CreateExternalPaymentJourney(req *http.Request, p
 	}
 
 	switch paymentSession.PaymentMethod {
-	case "GovPay":
+	case "credit-card":
 		paymentJourney := &models.ExternalPaymentJourney{}
 
 		gp := &GovPayService{PaymentService: *service}

--- a/service/external_paysession_test.go
+++ b/service/external_paysession_test.go
@@ -55,7 +55,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		}
 
 		paymentSession := models.PaymentResourceRest{
-			PaymentMethod: "GovPay",
+			PaymentMethod: "credit-card",
 			Amount:        "3",
 			Status:        InProgress.String(),
 			Costs:         []models.CostResourceRest{costResource},
@@ -86,7 +86,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		}
 
 		paymentSession := models.PaymentResourceRest{
-			PaymentMethod: "GovPay",
+			PaymentMethod: "credit-card",
 			Amount:        "3",
 			Status:        InProgress.String(),
 			Costs:         []models.CostResourceRest{costResource1, costResource2},
@@ -108,7 +108,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 
 		paymentSession := models.PaymentResourceRest{
-			PaymentMethod: "GovPay",
+			PaymentMethod: "credit-card",
 			Status:        InProgress.String(),
 		}
 
@@ -135,7 +135,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		}
 
 		paymentSession := models.PaymentResourceRest{
-			PaymentMethod: "GovPay",
+			PaymentMethod: "credit-card",
 			Amount:        "3",
 			Status:        InProgress.String(),
 			Costs:         []models.CostResourceRest{costResource},
@@ -170,7 +170,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		}
 
 		paymentSession := models.PaymentResourceRest{
-			PaymentMethod: "GovPay",
+			PaymentMethod: "credit-card",
 			Amount:        "4",
 			Status:        InProgress.String(),
 			Costs:         []models.CostResourceRest{costResource},
@@ -205,7 +205,7 @@ func TestUnitCreateExternalPayment(t *testing.T) {
 		}
 
 		paymentSession := models.PaymentResourceRest{
-			PaymentMethod: "GovPay",
+			PaymentMethod: "credit-card",
 			Amount:        "3",
 			Status:        InProgress.String(),
 			Costs:         []models.CostResourceRest{costResource},

--- a/service/payment_test.go
+++ b/service/payment_test.go
@@ -19,7 +19,7 @@ import (
 
 var defaultCost = models.CostResourceRest{
 	Amount:                  "10",
-	AvailablePaymentMethods: []string{"GovPay"},
+	AvailablePaymentMethods: []string{"credit-card"},
 	ClassOfPayment:          []string{"data-maintenance"},
 	Description:             "desc",
 	DescriptionIdentifier:   "identifier",
@@ -199,7 +199,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		So(status, ShouldEqual, Success)
 
 		So(paymentResourceRest.Amount, ShouldEqual, "10.00")
-		So(paymentResourceRest.AvailablePaymentMethods, ShouldResemble, []string{"GovPay"})
+		So(paymentResourceRest.AvailablePaymentMethods, ShouldResemble, []string{"credit-card"})
 		So(paymentResourceRest.CompletedAt, ShouldHaveSameTypeAs, time.Now())
 		So(paymentResourceRest.CreatedAt, ShouldHaveSameTypeAs, time.Now())
 		So(paymentResourceRest.CreatedBy, ShouldResemble, models.CreatedByRest{
@@ -257,7 +257,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		So(paymentResourceRest.Amount, ShouldEqual, "20.00")
-		So(paymentResourceRest.AvailablePaymentMethods, ShouldResemble, []string{"GovPay"})
+		So(paymentResourceRest.AvailablePaymentMethods, ShouldResemble, []string{"credit-card"})
 		So(paymentResourceRest.CompletedAt, ShouldHaveSameTypeAs, time.Now())
 		So(paymentResourceRest.CreatedAt, ShouldHaveSameTypeAs, time.Now())
 		So(paymentResourceRest.CreatedBy, ShouldResemble, models.CreatedByRest{
@@ -316,7 +316,7 @@ func TestUnitCreatePaymentSession(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		So(paymentResourceRest.Amount, ShouldEqual, "20.00")
-		So(paymentResourceRest.AvailablePaymentMethods, ShouldResemble, []string{"GovPay"})
+		So(paymentResourceRest.AvailablePaymentMethods, ShouldResemble, []string{"credit-card"})
 		So(paymentResourceRest.CompletedAt, ShouldHaveSameTypeAs, time.Now())
 		So(paymentResourceRest.CreatedAt, ShouldHaveSameTypeAs, time.Now())
 		So(paymentResourceRest.CreatedBy, ShouldResemble, models.CreatedByRest{
@@ -406,7 +406,7 @@ func TestUnitPatchPaymentSession(t *testing.T) {
 		httpmock.RegisterResponder("GET", "http://dummy-resource", jsonResponse)
 
 		resource := models.PaymentResourceRest{
-			PaymentMethod: "GovPay",
+			PaymentMethod: "credit-card",
 		}
 
 		responseType, err := mockPaymentService.PatchPaymentSession(req, "1234", resource)
@@ -559,7 +559,7 @@ func TestUnitGetPayment(t *testing.T) {
 			Costs: []models.CostResourceRest{
 				{
 					Amount:                  "10",
-					AvailablePaymentMethods: []string{"GovPay"},
+					AvailablePaymentMethods: []string{"credit-card"},
 					ClassOfPayment:          []string{"data-maintenance"},
 					Description:             "desc",
 					DescriptionIdentifier:   "identifier",
@@ -607,7 +607,7 @@ func TestUnitGetPayment(t *testing.T) {
 			Costs: []models.CostResourceRest{
 				{
 					Amount:                  "10",
-					AvailablePaymentMethods: []string{"GovPay"},
+					AvailablePaymentMethods: []string{"credit-card"},
 					ClassOfPayment:          []string{"data-maintenance"},
 					Description:             "desc",
 					DescriptionIdentifier:   "identifier",
@@ -615,7 +615,7 @@ func TestUnitGetPayment(t *testing.T) {
 				},
 				{
 					Amount:                  "10",
-					AvailablePaymentMethods: []string{"GovPay"},
+					AvailablePaymentMethods: []string{"credit-card"},
 					ClassOfPayment:          []string{"data-maintenance"},
 					Description:             "desc",
 					DescriptionIdentifier:   "identifier",


### PR DESCRIPTION
There's a discrepancy between the services that use the payments-service declaring `available_payment_methods` as `credit-card` whereas payments.web and payments.api were expecting `GovPay`. This change fixes that

### Type of change

* [X] Bug fix

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__