### PR TITLE
PayPal Invoice ID

### DIFF
--- a/service/paypal.go
+++ b/service/paypal.go
@@ -79,8 +79,7 @@ func (pp *PayPalService) CreatePaymentAndGenerateNextURL(req *http.Request, paym
 		paypal.OrderIntentCapture,
 		[]paypal.PurchaseUnitRequest{
 			{
-				ReferenceID: id,
-				InvoiceID:   id,
+				InvoiceID: id,
 				Amount: &paypal.PurchaseUnitAmount{
 					Value:    paymentResource.Amount,
 					Currency: "GBP",


### PR DESCRIPTION
Send ID to PayPal as Invoice ID, to enable searching in the dashboard