### PR TITLE
Fix status for bulk_refunds to only use status in the bulk refund object and not the payment session

### DIFF
--- a/dao/dao.go
+++ b/dao/dao.go
@@ -11,7 +11,7 @@ type DAO interface {
 	GetPaymentResource(string) (*models.PaymentResourceDB, error)
 	PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceDB) error
 	GetPaymentResourceByExternalPaymentStatusID(externalPaymentStatusID string) (*models.PaymentResourceDB, error)
-	CreateBulkRefund(externalPaymentStatusID string, status string, bulkRefund models.BulkRefundDB) error
+	CreateBulkRefund(externalPaymentStatusID string, bulkRefund models.BulkRefundDB) error
 	GetPaymentsWithRefundStatus() ([]models.PaymentResourceDB, error)
 }
 

--- a/dao/mock_dao.go
+++ b/dao/mock_dao.go
@@ -83,15 +83,15 @@ func (mr *MockDAOMockRecorder) GetPaymentResourceByExternalPaymentStatusID(exter
 }
 
 // CreateBulkRefund mocks base method
-func (m *MockDAO) CreateBulkRefund(externalPaymentStatusID, status string, bulkRefund models.BulkRefundDB) error {
-	ret := m.ctrl.Call(m, "CreateBulkRefund", externalPaymentStatusID, status, bulkRefund)
+func (m *MockDAO) CreateBulkRefund(externalPaymentStatusID string, bulkRefund models.BulkRefundDB) error {
+	ret := m.ctrl.Call(m, "CreateBulkRefund", externalPaymentStatusID, bulkRefund)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateBulkRefund indicates an expected call of CreateBulkRefund
-func (mr *MockDAOMockRecorder) CreateBulkRefund(externalPaymentStatusID, status, bulkRefund interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBulkRefund", reflect.TypeOf((*MockDAO)(nil).CreateBulkRefund), externalPaymentStatusID, status, bulkRefund)
+func (mr *MockDAOMockRecorder) CreateBulkRefund(externalPaymentStatusID, bulkRefund interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBulkRefund", reflect.TypeOf((*MockDAO)(nil).CreateBulkRefund), externalPaymentStatusID, bulkRefund)
 }
 
 // GetPaymentsWithRefundStatus mocks base method

--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -166,12 +166,11 @@ func (m *MongoService) GetPaymentResourceByExternalPaymentStatusID(externalPayme
 }
 
 // CreateBulkRefund creates or adds to the array of bulk refunds on a payment resource
-func (m *MongoService) CreateBulkRefund(externalPaymentStatusID string, status string, bulkRefund models.BulkRefundDB) error {
+func (m *MongoService) CreateBulkRefund(externalPaymentStatusID string, bulkRefund models.BulkRefundDB) error {
 	collection := m.db.Collection(m.CollectionName)
 
 	filter := bson.M{"external_payment_status_id": externalPaymentStatusID}
-	setStatus := bson.M{paymentStatus: status}
-	pushQuery := bson.M{"$push": bson.M{"bulk_refunds": bulkRefund}, "$set": setStatus}
+	pushQuery := bson.M{"$push": bson.M{"bulk_refunds": bulkRefund}}
 
 	update, err := collection.UpdateOne(context.Background(), filter, pushQuery)
 	if err != nil {
@@ -190,7 +189,7 @@ func (m *MongoService) GetPaymentsWithRefundStatus() ([]models.PaymentResourceDB
 	var payments []models.PaymentResourceDB
 
 	collection := m.db.Collection(m.CollectionName)
-	statusFilter := bson.M{paymentStatus: "refund-pending"}
+	statusFilter := bson.M{"bulk_refunds.status": "refund-pending"}
 	bulkRefundsFilter := bson.M{"bulk_refunds.0": bson.M{"$exists": true}}
 
 	paymentDBResources, err := collection.Find(context.Background(), bson.M{"$and": bson.A{statusFilter, bulkRefundsFilter}})

--- a/dao/mongo_test.go
+++ b/dao/mongo_test.go
@@ -77,7 +77,7 @@ func TestUnitCreateBulkRefund(t *testing.T) {
 
 		bulkRefund := models.BulkRefundDB{}
 
-		err := dao.CreateBulkRefund("id123", "status", bulkRefund)
+		err := dao.CreateBulkRefund("id123", bulkRefund)
 		So(err.Error(), ShouldEqual, "error updating bulk refund for payment with external status id [id123]: the Update operation must have a Deployment set before Execute can be called")
 	})
 }

--- a/handlers/bulk_refunds_test.go
+++ b/handlers/bulk_refunds_test.go
@@ -197,7 +197,7 @@ func TestUnitHandleGovPayBulkRefund(t *testing.T) {
 			Config:         *cfg,
 		}
 		mockDao.EXPECT().GetPaymentResourceByExternalPaymentStatusID(gomock.Any()).Return(&paymentSession, nil).AnyTimes()
-		mockDao.EXPECT().CreateBulkRefund(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("error")).AnyTimes()
+		mockDao.EXPECT().CreateBulkRefund(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error")).AnyTimes()
 
 		HandleGovPayBulkRefund(w, req)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
@@ -231,7 +231,7 @@ func TestUnitHandleGovPayBulkRefund(t *testing.T) {
 		}
 
 		mockDao.EXPECT().GetPaymentResourceByExternalPaymentStatusID(gomock.Any()).Return(&paymentSession, nil).AnyTimes()
-		mockDao.EXPECT().CreateBulkRefund(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockDao.EXPECT().CreateBulkRefund(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		HandleGovPayBulkRefund(w, req)
 		So(w.Code, ShouldEqual, http.StatusCreated)

--- a/service/refund.go
+++ b/service/refund.go
@@ -28,6 +28,21 @@ const (
 	RefundsStatusError     = "error"
 )
 
+// BulkRefundStatus Enum Type
+type BulkRefundStatus int
+
+// Enumeration containing all possible bulk refund statuses
+const (
+	BulkRefundPending PaymentStatus = 1 + iota
+	BulkRefundRequested
+)
+
+// String representation of bulk refund statuses
+var bulkRefundStatuses = [...]string{
+	"refund-pending",
+	"refund-requested",
+}
+
 type RefundService struct {
 	GovPayService  PaymentProviderService
 	PaymentService *PaymentService
@@ -197,7 +212,7 @@ func (service *RefundService) UpdateGovPayBatchRefund(ctx context.Context, batch
 		errs.Go(func() error {
 
 			bulkRefundDB := models.BulkRefundDB{
-				Status:            RefundPending,
+				Status:            BulkRefundPending.String(),
 				UploadedFilename:  filename,
 				UploadedAt:        time.Now().Truncate(time.Millisecond).String(),
 				UploadedBy:        user,
@@ -207,7 +222,7 @@ func (service *RefundService) UpdateGovPayBatchRefund(ctx context.Context, batch
 				ExternalRefundURL: "",
 			}
 
-			err := service.DAO.CreateBulkRefund(r.OrderCode, PendingRefund.String(), bulkRefundDB)
+			err := service.DAO.CreateBulkRefund(r.OrderCode, bulkRefundDB)
 			if err != nil {
 				log.Error(fmt.Errorf("error updating payment session in DB: %w", err))
 				return err

--- a/service/refund.go
+++ b/service/refund.go
@@ -33,7 +33,7 @@ type BulkRefundStatus int
 
 // Enumeration containing all possible bulk refund statuses
 const (
-	BulkRefundPending PaymentStatus = 1 + iota
+	BulkRefundPending BulkRefundStatus = 1 + iota
 	BulkRefundRequested
 )
 
@@ -41,6 +41,11 @@ const (
 var bulkRefundStatuses = [...]string{
 	"refund-pending",
 	"refund-requested",
+}
+
+// String returns the string representation of the bulk refund status
+func (bulkRefundStatus BulkRefundStatus) String() string {
+	return bulkRefundStatuses[bulkRefundStatus-1]
 }
 
 type RefundService struct {

--- a/service/refund_test.go
+++ b/service/refund_test.go
@@ -449,7 +449,7 @@ func TestUnitUpdateGovPayBatchRefund(t *testing.T) {
 
 		batchRefund := generateXMLBatchRefund()
 
-		mockDao.EXPECT().CreateBulkRefund(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("error")).AnyTimes()
+		mockDao.EXPECT().CreateBulkRefund(gomock.Any(), gomock.Any()).Return(fmt.Errorf("error")).AnyTimes()
 		err := service.UpdateGovPayBatchRefund(req.Context(), batchRefund, "filename", "userID")
 
 		So(err, ShouldNotBeNil)
@@ -462,7 +462,7 @@ func TestUnitUpdateGovPayBatchRefund(t *testing.T) {
 
 		batchRefund := generateXMLBatchRefund()
 
-		mockDao.EXPECT().CreateBulkRefund(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockDao.EXPECT().CreateBulkRefund(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		err := service.UpdateGovPayBatchRefund(req.Context(), batchRefund, "filename", "userID")
 
 		So(err, ShouldBeNil)


### PR DESCRIPTION
__Short description outlining key changes/additions__
The code changes updating the status in the bulk refund object within the array. It also changes how we retrieve payment sessions by checking if a payment session has a bulk refund within the bulk refunds array with a status of `refund-pending`

__JIRA Ticket Number__

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__