### PR TITLE
Add external payment transaction ID and return as part of get details

### DIFF
--- a/handlers/callback.go
+++ b/handlers/callback.go
@@ -199,6 +199,9 @@ func HandlePayPalCallback(externalPaymentSvc service.PaymentProviderService) htt
 			default:
 				paymentSession.Status = service.Failed.String()
 			}
+
+			// Add external transaction ID to paymentSession metadata
+			paymentSession.MetaData.ExternalPaymentTransactionID = response.PurchaseUnits[0].Payments.Captures[0].ID
 		}
 
 		// If order status is created, then the payment has been cancelled

--- a/handlers/payments_test.go
+++ b/handlers/payments_test.go
@@ -399,8 +399,20 @@ func TestUnitHandleGetPaymentDetails(t *testing.T) {
 
 		createTime, _ := time.Parse("2006-01-02", "2003-02-01")
 		paypalStatus := paypal.Order{
-			CreateTime: &createTime,
+			ID:         "ABC123",
 			Status:     "COMPLETED",
+			CreateTime: &createTime,
+			PurchaseUnits: []paypal.PurchaseUnit{
+				{
+					Payments: &paypal.CapturedPayments{
+						Captures: []paypal.CaptureAmount{
+							{
+								ID: "1122",
+							},
+						},
+					},
+				},
+			},
 		}
 
 		mockPayPalSDK.EXPECT().GetOrder(gomock.Any(), "123456").Return(&paypalStatus, nil)

--- a/models/payment_db.go
+++ b/models/payment_db.go
@@ -4,14 +4,15 @@ import "time"
 
 // PaymentResourceDB contains all payment details to be stored in the DB
 type PaymentResourceDB struct {
-	ID                       string                `bson:"_id"`
-	RedirectURI              string                `bson:"redirect_uri"`
-	State                    string                `bson:"state"`
-	ExternalPaymentStatusURI string                `bson:"external_payment_status_url"`
-	ExternalPaymentStatusID  string                `bson:"external_payment_status_id"`
-	Data                     PaymentResourceDataDB `bson:"data"`
-	Refunds                  []RefundResourceDB    `bson:"refunds"`
-	BulkRefund               []BulkRefundDB        `bson:"bulk_refunds,omitempty"`
+	ID                           string                `bson:"_id"`
+	RedirectURI                  string                `bson:"redirect_uri"`
+	State                        string                `bson:"state"`
+	ExternalPaymentStatusURI     string                `bson:"external_payment_status_url"`
+	ExternalPaymentStatusID      string                `bson:"external_payment_status_id"`
+	ExternalPaymentTransactionID string                `bson:"external_payment_transaction_id`
+	Data                         PaymentResourceDataDB `bson:"data"`
+	Refunds                      []RefundResourceDB    `bson:"refunds"`
+	BulkRefund                   []BulkRefundDB        `bson:"bulk_refunds,omitempty"`
 }
 
 // PaymentResourceDataDB is public facing payment details to be returned in the response

--- a/models/payment_rest.go
+++ b/models/payment_rest.go
@@ -33,11 +33,12 @@ type PaymentResourceRest struct {
 
 // PaymentResourceMetaDataRest contains all metadata fields that are relevant to the payment resource but not part of the Rest resource
 type PaymentResourceMetaDataRest struct {
-	ID                       string
-	RedirectURI              string
-	State                    string
-	ExternalPaymentStatusURI string
-	ExternalPaymentStatusID  string
+	ID                           string
+	RedirectURI                  string
+	State                        string
+	ExternalPaymentStatusURI     string
+	ExternalPaymentStatusID      string
+	ExternalPaymentTransactionID string
 }
 
 // CreatedByRest is the user who is creating the payment session

--- a/service/paypal.go
+++ b/service/paypal.go
@@ -162,7 +162,7 @@ func (pp *PayPalService) GetPaymentDetails(paymentResource *models.PaymentResour
 
 	paymentDetails := &models.PaymentDetails{
 		CardType:          "",
-		ExternalPaymentID: order.ID,
+		ExternalPaymentID: order.PurchaseUnits[0].Payments.Captures[0].ID,
 		TransactionDate:   order.CreateTime.String(),
 		PaymentStatus:     order.Status,
 	}

--- a/service/paypal_test.go
+++ b/service/paypal_test.go
@@ -345,6 +345,17 @@ func TestUnitGetPaymentDetails(t *testing.T) {
 			ID:         "ABC123",
 			Status:     "COMPLETED",
 			CreateTime: &createTime,
+			PurchaseUnits: []paypal.PurchaseUnit{
+				{
+					Payments: &paypal.CapturedPayments{
+						Captures: []paypal.CaptureAmount{
+							{
+								ID: "1122",
+							},
+						},
+					},
+				},
+			},
 		}
 
 		mockPayPalSDK.EXPECT().GetOrder(gomock.Any(), gomock.Any()).Return(&paypalOrder, nil)
@@ -358,7 +369,7 @@ func TestUnitGetPaymentDetails(t *testing.T) {
 		paymentDetails, responseType, err := mockPayPalService.GetPaymentDetails(&resource)
 
 		So(paymentDetails.CardType, ShouldBeEmpty)
-		So(paymentDetails.ExternalPaymentID, ShouldEqual, "ABC123")
+		So(paymentDetails.ExternalPaymentID, ShouldEqual, "1122")
 		So(paymentDetails.TransactionDate, ShouldEqual, "2003-02-01 00:00:00 +0000 UTC")
 		So(paymentDetails.PaymentStatus, ShouldEqual, "COMPLETED")
 		So(responseType, ShouldEqual, Success)

--- a/transformers/payment.go
+++ b/transformers/payment.go
@@ -34,8 +34,9 @@ func (pt PaymentTransformer) TransformToDB(rest models.PaymentResourceRest) mode
 	paymentResourceData.Links = models.PaymentLinksDB(rest.Links)
 
 	paymentResource := models.PaymentResourceDB{
-		Data:    paymentResourceData,
-		Refunds: getRefundsDB(rest.Refunds),
+		ExternalPaymentTransactionID: rest.MetaData.ExternalPaymentTransactionID,
+		Data:                         paymentResourceData,
+		Refunds:                      getRefundsDB(rest.Refunds),
 	}
 
 	return paymentResource


### PR DESCRIPTION
__Short description outlining key changes/additions__
Add external payment transaction ID to payment details and store in Mongo.
This will be returned as part of the get details endpoint for PayPal.

__JIRA Ticket Number__
BI-10901

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__