### PR TITLE
Add validation for refund creation

### DIFF
--- a/handlers/refunds.go
+++ b/handlers/refunds.go
@@ -57,6 +57,12 @@ func HandleCreateRefund(w http.ResponseWriter, req *http.Request) {
 		case service.NotFound:
 			w.WriteHeader(http.StatusNotFound)
 			return
+		case service.Forbidden:
+			w.WriteHeader(http.StatusForbidden)
+			return
+		case service.Conflict:
+			w.WriteHeader(http.StatusConflict)
+			return
 		default:
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/models/refund_db.go
+++ b/models/refund_db.go
@@ -1,9 +1,11 @@
 package models
 
+// RefundResourceDB represents the database refund structure
 type RefundResourceDB struct {
 	RefundId          string `bson:"refund_id"`
 	CreatedAt         string `bson:"created_at"`
 	Amount            int    `bson:"amount"`
 	Status            string `bson:"status"`
 	ExternalRefundUrl string `bson:"external_refund_url"`
+	RefundReference   string `bson:"refund_reference"`
 }

--- a/models/refund_rest.go
+++ b/models/refund_rest.go
@@ -1,9 +1,12 @@
 package models
 
+// CreateRefundRequest contains the request data to create a refund
 type CreateRefundRequest struct {
-	Amount int `json:"amount"`
+	Amount          int    `json:"amount"`
+	RefundReference string `json:"refund_reference,omitempty"`
 }
 
+// RefundResponse is the data contained in a refund response
 type RefundResponse struct {
 	RefundId        string `json:"refund_id"`
 	CreatedDateTime string `json:"created_date_time"`
@@ -11,10 +14,12 @@ type RefundResponse struct {
 	Status          string `json:"status"`
 }
 
+// RefundResourceRest is the data contained in a refund resource
 type RefundResourceRest struct {
 	RefundId          string `json:"refund_id"`
 	CreatedAt         string `json:"created_at"`
 	Amount            int    `json:"amount"`
 	Status            string `json:"status"`
 	ExternalRefundUrl string `json:"external_refund_url"`
+	RefundReference   string `json:"refund_reference"`
 }

--- a/service/refund.go
+++ b/service/refund.go
@@ -20,13 +20,15 @@ import (
 )
 
 const (
-	RefundPending          = "pending"
-	RefundUnavailable      = "unavailable"
-	RefundAvailable        = "available"
-	RefundFull             = "full"
-	RefundsStatusSuccess   = "success"
-	RefundsStatusSubmitted = "submitted"
-	RefundsStatusError     = "error"
+	RefundPending           = "pending"
+	RefundUnavailable       = "unavailable"
+	RefundAvailable         = "available"
+	RefundFull              = "full"
+	RefundsStatusSuccess    = "success"
+	RefundsStatusSubmitted  = "submitted"
+	RefundsStatusError      = "error"
+	PaymentMethodCreditCard = "credit-card"
+	PaymentMethodPayPal     = "PayPal"
 )
 
 // BulkRefundStatus Enum Type
@@ -63,7 +65,7 @@ func (service *RefundService) CreateRefund(req *http.Request, id string, createR
 	paymentSession, _, _ := service.PaymentService.GetPaymentSession(req, id)
 
 	// Currently, refunds are only enabled for Gov Pay
-	if paymentSession.PaymentMethod != "credit-card" {
+	if paymentSession.PaymentMethod != PaymentMethodCreditCard {
 		err := fmt.Errorf("unexpected payment method: %s", paymentSession.PaymentMethod)
 		return nil, nil, Forbidden, err
 	}
@@ -231,7 +233,7 @@ func validateGovPayRefund(paymentSession *models.PaymentResourceDB, refund model
 		return fmt.Sprintf("payment session with id [%s] not found", refund.OrderCode)
 	}
 
-	if paymentSession.Data.PaymentMethod != "credit-card" {
+	if paymentSession.Data.PaymentMethod != PaymentMethodCreditCard {
 		return fmt.Sprintf("payment with order code [%s] has not been made via Gov.Pay - refund not eligible", refund.OrderCode)
 	}
 
@@ -251,7 +253,7 @@ func validatePayPalRefund(paymentSession *models.PaymentResourceDB, refund model
 		return fmt.Sprintf("payment session with id [%s] not found", refund.OrderCode)
 	}
 
-	if paymentSession.Data.PaymentMethod != "PayPal" {
+	if paymentSession.Data.PaymentMethod != PaymentMethodPayPal {
 		return fmt.Sprintf("payment with order code [%s] has not been made via PayPal - refund not eligible", refund.OrderCode)
 	}
 
@@ -342,12 +344,12 @@ func (service *RefundService) ProcessBatchRefund(req *http.Request) []error {
 
 	for _, p := range payments {
 		switch p.Data.PaymentMethod {
-		case "credit-card":
+		case PaymentMethodCreditCard:
 			err := service.processGovPayBatchRefund(req, p)
 			if err != nil {
 				errorList = append(errorList, err)
 			}
-		case "PayPal":
+		case PaymentMethodPayPal:
 			err := service.processPayPalBatchRefund(req, p)
 			if err != nil {
 				errorList = append(errorList, err)

--- a/service/response_type.go
+++ b/service/response_type.go
@@ -19,11 +19,14 @@ const (
 	// Success response
 	Success
 
-	// Cost Resource Not Found response
+	// CostsNotFound response
 	CostsNotFound
 
-	// Costs Gone response
+	// CostsGone response
 	CostsGone
+
+	// Conflict response
+	Conflict
 )
 
 var vals = [...]string{
@@ -34,6 +37,7 @@ var vals = [...]string{
 	"success",
 	"costs-not-found",
 	"costs-gone",
+	"conflict",
 }
 
 // String representation of `ResponseType`

--- a/transformers/payment.go
+++ b/transformers/payment.go
@@ -90,6 +90,7 @@ func getRefundDB(refund models.RefundResourceRest) models.RefundResourceDB {
 		Amount:            refund.Amount,
 		Status:            refund.Status,
 		ExternalRefundUrl: refund.ExternalRefundUrl,
+		RefundReference:   refund.RefundReference,
 	}
 }
 
@@ -110,5 +111,6 @@ func getRefundRest(refund models.RefundResourceDB) models.RefundResourceRest {
 		Amount:            refund.Amount,
 		Status:            refund.Status,
 		ExternalRefundUrl: refund.ExternalRefundUrl,
+		RefundReference:   refund.RefundReference,
 	}
 }


### PR DESCRIPTION
Add validation for refund creation:

- Return 403 Forbidden error if payment method == PayPal

- Return 409 Conflict error if refund reference field is not unique on this payment UNLESS other uses of this refund reference are cancelled or failed (this enables retries but blocks concurrent requests)

ROE-1462


### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__