### PR TITLE
Mark Failed Pending Refunds in DB

### DIFF
--- a/dao/dao.go
+++ b/dao/dao.go
@@ -17,7 +17,9 @@ type DAO interface {
 	GetPaymentsWithRefundStatus() ([]models.PaymentResourceDB, error)
 	GetPaymentsWithRefundPendingStatus() ([]models.PaymentResourceDB, error)
 	GetPaymentRefunds(string) ([]models.RefundResourceDB, error)
-	PatchPaymentsWithRefundPendingStatus(id string, isPaid bool, paymentUpdate *models.PaymentResourceDB) (models.PaymentResourceDB, error)
+	PatchRefundSuccessStatus(id string, isPaid bool, paymentUpdate *models.PaymentResourceDB) (models.PaymentResourceDB, error)
+	PatchRefundReconciliationFailedStatus(id string, paymentUpdate *models.PaymentResourceDB) (models.PaymentResourceDB, error)
+	PatchRefundStatus(id string, isRefunded bool, isFailed bool, refundStatus string, paymentUpdate *models.PaymentResourceDB) (models.PaymentResourceDB, error)
 }
 
 // NewDAO will create a new instance of the DAO interface.

--- a/dao/mock_dao.go
+++ b/dao/mock_dao.go
@@ -75,26 +75,26 @@ func (mr *MockDAOMockRecorder) CreatePaymentResource(paymentResource interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePaymentResource", reflect.TypeOf((*MockDAO)(nil).CreatePaymentResource), paymentResource)
 }
 
-// GetPaymentResource mocks base method.
-func (m *MockDAO) GetPaymentResource(arg0 string) (*models.PaymentResourceDB, error) {
+// GetPaymentRefunds mocks base method.
+func (m *MockDAO) GetPaymentRefunds(arg0 string) ([]models.RefundResourceDB, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPaymentResource", arg0)
-	ret0, _ := ret[0].(*models.PaymentResourceDB)
+	ret := m.ctrl.Call(m, "GetPaymentRefunds", arg0)
+	ret0, _ := ret[0].([]models.RefundResourceDB)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPaymentRefunds indicates an expected call of GetPaymentRefunds.
-func (mr *MockDAOMockRecorder) GetPaymentRefunds(paymentResource interface{}) *gomock.Call {
+func (mr *MockDAOMockRecorder) GetPaymentRefunds(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentRefunds", reflect.TypeOf((*MockDAO)(nil).GetPaymentRefunds), paymentResource)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentRefunds", reflect.TypeOf((*MockDAO)(nil).GetPaymentRefunds), arg0)
 }
 
-// GetPaymentRefunds mocks base method.
-func (m *MockDAO) GetPaymentRefunds(paymentId string) ([]models.RefundResourceDB, error) {
+// GetPaymentResource mocks base method.
+func (m *MockDAO) GetPaymentResource(arg0 string) (*models.PaymentResourceDB, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPaymentRefunds", paymentId)
-	ret0, _ := ret[0].([]models.RefundResourceDB)
+	ret := m.ctrl.Call(m, "GetPaymentResource", arg0)
+	ret0, _ := ret[0].(*models.PaymentResourceDB)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -135,15 +135,6 @@ func (mr *MockDAOMockRecorder) GetPaymentResourceByProviderID(providerID interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentResourceByProviderID", reflect.TypeOf((*MockDAO)(nil).GetPaymentResourceByProviderID), providerID)
 }
 
-// GetPaymentsWithRefundStatus mocks base method.
-func (m *MockDAO) GetPaymentsWithRefundStatus() ([]models.PaymentResourceDB, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPaymentsWithRefundStatus")
-	ret0, _ := ret[0].([]models.PaymentResourceDB)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
 // GetPaymentsWithRefundPendingStatus mocks base method.
 func (m *MockDAO) GetPaymentsWithRefundPendingStatus() ([]models.PaymentResourceDB, error) {
 	m.ctrl.T.Helper()
@@ -153,17 +144,25 @@ func (m *MockDAO) GetPaymentsWithRefundPendingStatus() ([]models.PaymentResource
 	return ret0, ret1
 }
 
+// GetPaymentsWithRefundPendingStatus indicates an expected call of GetPaymentsWithRefundPendingStatus.
+func (mr *MockDAOMockRecorder) GetPaymentsWithRefundPendingStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentsWithRefundPendingStatus", reflect.TypeOf((*MockDAO)(nil).GetPaymentsWithRefundPendingStatus))
+}
+
+// GetPaymentsWithRefundStatus mocks base method.
+func (m *MockDAO) GetPaymentsWithRefundStatus() ([]models.PaymentResourceDB, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPaymentsWithRefundStatus")
+	ret0, _ := ret[0].([]models.PaymentResourceDB)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
 
 // GetPaymentsWithRefundStatus indicates an expected call of GetPaymentsWithRefundStatus.
 func (mr *MockDAOMockRecorder) GetPaymentsWithRefundStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentsWithRefundStatus", reflect.TypeOf((*MockDAO)(nil).GetPaymentsWithRefundStatus))
-}
-
-// GetPaymentsWithRefundPendingStatus indicates an expected call of GetPaymentsWithRefundPendingStatus.
-func (mr *MockDAOMockRecorder) GetPaymentsWithRefundPendingStatus() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentsWithRefundPendingStatus", reflect.TypeOf((*MockDAO)(nil).GetPaymentsWithRefundPendingStatus))
 }
 
 // PatchPaymentResource mocks base method.
@@ -174,17 +173,53 @@ func (m *MockDAO) PatchPaymentResource(id string, paymentUpdate *models.PaymentR
 	return ret0
 }
 
-// PatchPaymentsWithRefundPendingStatus mocks base method.
-func (m *MockDAO) PatchPaymentsWithRefundPendingStatus(id string, isPaid bool, paymentUpdate *models.PaymentResourceDB) (models.PaymentResourceDB, error) {
+// PatchPaymentResource indicates an expected call of PatchPaymentResource.
+func (mr *MockDAOMockRecorder) PatchPaymentResource(id, paymentUpdate interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchPaymentResource", reflect.TypeOf((*MockDAO)(nil).PatchPaymentResource), id, paymentUpdate)
+}
+
+// PatchRefundReconciliationFailedStatus mocks base method.
+func (m *MockDAO) PatchRefundReconciliationFailedStatus(id string, paymentUpdate *models.PaymentResourceDB) (models.PaymentResourceDB, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PatchPaymentsWithRefundPendingStatus", id, isPaid, paymentUpdate)
+	ret := m.ctrl.Call(m, "PatchRefundReconciliationFailedStatus", id, paymentUpdate)
 	ret0, _ := ret[0].(models.PaymentResourceDB)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// PatchPaymentResource indicates an expected call of PatchPaymentResource.
-func (mr *MockDAOMockRecorder) PatchPaymentResource(id, paymentUpdate interface{}) *gomock.Call {
+// PatchRefundReconciliationFailedStatus indicates an expected call of PatchRefundReconciliationFailedStatus.
+func (mr *MockDAOMockRecorder) PatchRefundReconciliationFailedStatus(id, paymentUpdate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchPaymentResource", reflect.TypeOf((*MockDAO)(nil).PatchPaymentResource), id, paymentUpdate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchRefundReconciliationFailedStatus", reflect.TypeOf((*MockDAO)(nil).PatchRefundReconciliationFailedStatus), id, paymentUpdate)
+}
+
+// PatchRefundStatus mocks base method.
+func (m *MockDAO) PatchRefundStatus(id string, isRefunded, isFailed bool, refundStatus string, paymentUpdate *models.PaymentResourceDB) (models.PaymentResourceDB, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchRefundStatus", id, isRefunded, isFailed, refundStatus, paymentUpdate)
+	ret0, _ := ret[0].(models.PaymentResourceDB)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PatchRefundStatus indicates an expected call of PatchRefundStatus.
+func (mr *MockDAOMockRecorder) PatchRefundStatus(id, isRefunded, isFailed, refundStatus, paymentUpdate interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchRefundStatus", reflect.TypeOf((*MockDAO)(nil).PatchRefundStatus), id, isRefunded, isFailed, refundStatus, paymentUpdate)
+}
+
+// PatchRefundSuccessStatus mocks base method.
+func (m *MockDAO) PatchRefundSuccessStatus(id string, isPaid bool, paymentUpdate *models.PaymentResourceDB) (models.PaymentResourceDB, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchRefundSuccessStatus", id, isPaid, paymentUpdate)
+	ret0, _ := ret[0].(models.PaymentResourceDB)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PatchRefundSuccessStatus indicates an expected call of PatchRefundSuccessStatus.
+func (mr *MockDAOMockRecorder) PatchRefundSuccessStatus(id, isPaid, paymentUpdate interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchRefundSuccessStatus", reflect.TypeOf((*MockDAO)(nil).PatchRefundSuccessStatus), id, isPaid, paymentUpdate)
 }

--- a/dao/mongo_driver_test.go
+++ b/dao/mongo_driver_test.go
@@ -291,7 +291,7 @@ func TestUnitGetPaymentResourceByExternalPaymentTransactionIDDriver(t *testing.T
 	})
 
 	mt.Run("GetPaymentResource with error findone", func(mt *mtest.T) {
-		
+
 		mt.AddMockResponses(mtest.CreateCommandErrorResponse(commandError))
 
 		mongoService.db = mt.DB
@@ -592,7 +592,7 @@ func TestUnitPatchPaymentsWithRefundPendingStatusDriver(t *testing.T) {
 		})
 
 		mongoService.db = mt.DB
-		paymentRefunds, err := mongoService.PatchPaymentsWithRefundPendingStatus("id", true, &paymentResource)
+		paymentRefunds, err := mongoService.PatchRefundSuccessStatus("id", true, &paymentResource)
 
 		assert.Nil(t, err)
 		assert.NotNil(t, paymentRefunds)
@@ -602,7 +602,7 @@ func TestUnitPatchPaymentsWithRefundPendingStatusDriver(t *testing.T) {
 		mt.AddMockResponses(mtest.CreateCommandErrorResponse(commandError))
 
 		mongoService.db = mt.DB
-		paymentRefunds, err := mongoService.PatchPaymentsWithRefundPendingStatus("id", true, &paymentResource)
+		paymentRefunds, err := mongoService.PatchRefundSuccessStatus("id", true, &paymentResource)
 
 		assert.NotNil(t, err)
 		assert.NotNil(t, paymentRefunds)
@@ -628,7 +628,7 @@ func TestUnitPatchPaymentsWithRefundPendingStatusDriver(t *testing.T) {
 		mt.AddMockResponses(response)
 		mongoService.db = mt.DB
 
-		paymentRefunds, err := mongoService.PatchPaymentsWithRefundPendingStatus("id", true, &paymentResource)
+		paymentRefunds, err := mongoService.PatchRefundSuccessStatus("id", true, &paymentResource)
 		assert.NotNil(t, paymentRefunds)
 		assert.NotNil(t, err)
 		assert.Equal(t, err.Error(), "mongo: no documents in result")

--- a/dao/mongo_test.go
+++ b/dao/mongo_test.go
@@ -121,7 +121,7 @@ func TestUnitPatchPaymentsWithRefundPendingStatus(t *testing.T) {
 			ExternalPaymentTransactionID: "id456",
 			Refunds:                      refundDatas,
 		}
-		_, err := dao.PatchPaymentsWithRefundPendingStatus("id123", true, &resource)
+		_, err := dao.PatchRefundSuccessStatus("id123", true, &resource)
 		So(err.Error(), ShouldEqual, "the FindAndModify operation must have a Deployment set before Execute can be called")
 	})
 }


### PR DESCRIPTION
If the check to the external payment provider fails, set the refund status to `refund-reconciliation-failed` to prevent blocking other refund requests

ROE-1984

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__