### PR TITLE
Remove refund-reconciliation-failed status

### DIFF
--- a/dao/dao.go
+++ b/dao/dao.go
@@ -19,8 +19,8 @@ type DAO interface {
 	GetPaymentsWithRefundPendingStatus() ([]models.PaymentResourceDB, error)
 	GetPaymentRefunds(string) ([]models.RefundResourceDB, error)
 	PatchRefundSuccessStatus(id string, isPaid bool, paymentUpdate *models.PaymentResourceDB) (models.PaymentResourceDB, error)
-	PatchRefundReconciliationFailedStatus(id string, paymentUpdate *models.PaymentResourceDB) (models.PaymentResourceDB, error)
 	PatchRefundStatus(id string, isRefunded bool, isFailed bool, refundStatus string, paymentUpdate *models.PaymentResourceDB) (models.PaymentResourceDB, error)
+	IncrementRefundAttempts(paymentID string, paymentUpdate *models.PaymentResourceDB) error
 }
 
 // NewDAO will create a new instance of the DAO interface.

--- a/dao/mock_dao.go
+++ b/dao/mock_dao.go
@@ -181,6 +181,20 @@ func (mr *MockDAOMockRecorder) GetPaymentsWithRefundStatus() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPaymentsWithRefundStatus", reflect.TypeOf((*MockDAO)(nil).GetPaymentsWithRefundStatus))
 }
 
+// IncrementRefundAttempts mocks base method.
+func (m *MockDAO) IncrementRefundAttempts(paymentID string, paymentUpdate *models.PaymentResourceDB) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IncrementRefundAttempts", paymentID, paymentUpdate)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IncrementRefundAttempts indicates an expected call of IncrementRefundAttempts.
+func (mr *MockDAOMockRecorder) IncrementRefundAttempts(paymentID, paymentUpdate interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncrementRefundAttempts", reflect.TypeOf((*MockDAO)(nil).IncrementRefundAttempts), paymentID, paymentUpdate)
+}
+
 // PatchPaymentResource mocks base method.
 func (m *MockDAO) PatchPaymentResource(id string, paymentUpdate *models.PaymentResourceDB) error {
 	m.ctrl.T.Helper()
@@ -193,21 +207,6 @@ func (m *MockDAO) PatchPaymentResource(id string, paymentUpdate *models.PaymentR
 func (mr *MockDAOMockRecorder) PatchPaymentResource(id, paymentUpdate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchPaymentResource", reflect.TypeOf((*MockDAO)(nil).PatchPaymentResource), id, paymentUpdate)
-}
-
-// PatchRefundReconciliationFailedStatus mocks base method.
-func (m *MockDAO) PatchRefundReconciliationFailedStatus(id string, paymentUpdate *models.PaymentResourceDB) (models.PaymentResourceDB, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PatchRefundReconciliationFailedStatus", id, paymentUpdate)
-	ret0, _ := ret[0].(models.PaymentResourceDB)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// PatchRefundReconciliationFailedStatus indicates an expected call of PatchRefundReconciliationFailedStatus.
-func (mr *MockDAOMockRecorder) PatchRefundReconciliationFailedStatus(id, paymentUpdate interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchRefundReconciliationFailedStatus", reflect.TypeOf((*MockDAO)(nil).PatchRefundReconciliationFailedStatus), id, paymentUpdate)
 }
 
 // PatchRefundStatus mocks base method.

--- a/dao/mongo_test.go
+++ b/dao/mongo_test.go
@@ -137,3 +137,35 @@ func TestUnitGetPaymentRefunds(t *testing.T) {
 		So(err.Error(), ShouldEqual, "the Find operation must have a Deployment set before Execute can be called")
 	})
 }
+
+func TestUnitIncrementRefundAttempts(t *testing.T) {
+	Convey("Increment refund attempts", t, func() {
+		cfg, _ := config.Get()
+		client = &mongo.Client{}
+		dao := NewDAO(cfg)
+
+		refundData := models.RefundResourceDB{
+			RefundId:          "sasaswewq23wsw",
+			CreatedAt:         "2020-11-19T12:57:30.Z06Z",
+			Amount:            800.0,
+			Status:            "pending",
+			ExternalRefundUrl: "https://pulicapi.payments.service.gov.uk",
+		}
+		refundDatas := []models.RefundResourceDB{refundData}
+
+		resource := models.PaymentResourceDB{
+			Data: models.PaymentResourceDataDB{
+				PaymentMethod: "credit-card",
+				Status:        "pending",
+				CompletedAt:   time.Now(),
+				ProviderID:    "id123",
+			},
+			ExternalPaymentStatusURI:     "companieshouse.gov.uk",
+			ExternalPaymentStatusID:      "id123",
+			ExternalPaymentTransactionID: "id456",
+			Refunds:                      refundDatas,
+		}
+		err := dao.IncrementRefundAttempts("id123", &resource)
+		So(err.Error(), ShouldEqual, "the FindAndModify operation must have a Deployment set before Execute can be called")
+	})
+}

--- a/service/refund.go
+++ b/service/refund.go
@@ -20,15 +20,16 @@ import (
 )
 
 const (
-	RefundPending           = "pending"
-	RefundUnavailable       = "unavailable"
-	RefundAvailable         = "available"
-	RefundFull              = "full"
-	RefundsStatusSuccess    = "success"
-	RefundsStatusSubmitted  = "submitted"
-	RefundsStatusError      = "error"
-	PaymentMethodCreditCard = "credit-card"
-	PaymentMethodPayPal     = "PayPal"
+	RefundPending             = "pending"
+	RefundUnavailable         = "unavailable"
+	RefundAvailable           = "available"
+	RefundFull                = "full"
+	RefundsStatusSuccess      = "success"
+	RefundsStatusSubmitted    = "submitted"
+	RefundsStatusError        = "error"
+	PaymentMethodCreditCard   = "credit-card"
+	PaymentMethodPayPal       = "PayPal"
+	ErrorIncrementingAttempts = "error incrementing attempts in DB: [%w]"
 )
 
 // BulkRefundStatus Enum Type
@@ -523,7 +524,7 @@ func (service *RefundService) checkGovPayAndUpdateRefundStatus(req *http.Request
 				log.ErrorR(req, fmt.Errorf("error getting payment resource ID [%s]: [%w]", x.ID, err))
 				err := service.DAO.IncrementRefundAttempts(x.ID, &x)
 				if err != nil {
-					log.ErrorR(req, fmt.Errorf("error incrementing attempts in DB: [%w]", err))
+					log.ErrorR(req, fmt.Errorf(ErrorIncrementingAttempts, err))
 				}
 				continue
 			}
@@ -532,7 +533,7 @@ func (service *RefundService) checkGovPayAndUpdateRefundStatus(req *http.Request
 				log.ErrorR(req, fmt.Errorf("not found error from payment service session with payment ID:[%s]", x.ID))
 				err := service.DAO.IncrementRefundAttempts(x.ID, &x)
 				if err != nil {
-					log.ErrorR(req, fmt.Errorf("error incrementing attempts in DB: [%w]", err))
+					log.ErrorR(req, fmt.Errorf(ErrorIncrementingAttempts, err))
 				}
 				continue
 			}
@@ -543,7 +544,7 @@ func (service *RefundService) checkGovPayAndUpdateRefundStatus(req *http.Request
 				log.ErrorR(req, fmt.Errorf("error getting refund status for ID [%s] [%w]", refund.RefundId, err))
 				err := service.DAO.IncrementRefundAttempts(x.ID, &x)
 				if err != nil {
-					log.ErrorR(req, fmt.Errorf("error incrementing attempts in DB: [%w]", err))
+					log.ErrorR(req, fmt.Errorf(ErrorIncrementingAttempts, err))
 				}
 				continue
 			}

--- a/service/refund.go
+++ b/service/refund.go
@@ -521,18 +521,18 @@ func (service *RefundService) checkGovPayAndUpdateRefundStatus(req *http.Request
 
 			if err != nil {
 				log.ErrorR(req, fmt.Errorf("error getting payment resource ID [%s]: [%w]", x.ID, err))
-				_, err := service.DAO.PatchRefundReconciliationFailedStatus(x.ID, &x)
+				err := service.DAO.IncrementRefundAttempts(x.ID, &x)
 				if err != nil {
-					log.ErrorR(req, fmt.Errorf("error storing status to DB: [%w]", err))
+					log.ErrorR(req, fmt.Errorf("error incrementing attempts in DB: [%w]", err))
 				}
 				continue
 			}
 
 			if response == NotFound {
 				log.ErrorR(req, fmt.Errorf("not found error from payment service session with payment ID:[%s]", x.ID))
-				_, err := service.DAO.PatchRefundReconciliationFailedStatus(x.ID, &x)
+				err := service.DAO.IncrementRefundAttempts(x.ID, &x)
 				if err != nil {
-					log.ErrorR(req, fmt.Errorf("error storing status to DB: [%w]", err))
+					log.ErrorR(req, fmt.Errorf("error incrementing attempts in DB: [%w]", err))
 				}
 				continue
 			}
@@ -541,9 +541,9 @@ func (service *RefundService) checkGovPayAndUpdateRefundStatus(req *http.Request
 
 			if err != nil {
 				log.ErrorR(req, fmt.Errorf("error getting refund status for ID [%s] [%w]", refund.RefundId, err))
-				_, err := service.DAO.PatchRefundReconciliationFailedStatus(x.ID, &x)
+				err := service.DAO.IncrementRefundAttempts(x.ID, &x)
 				if err != nil {
-					log.ErrorR(req, fmt.Errorf("error storing status to DB: [%w]", err))
+					log.ErrorR(req, fmt.Errorf("error incrementing attempts in DB: [%w]", err))
 				}
 				continue
 			}
@@ -561,11 +561,6 @@ func (service *RefundService) checkGovPayAndUpdateRefundStatus(req *http.Request
 			}
 		} else {
 			log.ErrorR(req, fmt.Errorf("no refund found with payment Id: [%s]", x.ID))
-			_, err := service.DAO.PatchRefundReconciliationFailedStatus(x.ID, &x)
-			if err != nil {
-				log.ErrorR(req, fmt.Errorf("error storing status to DB: [%w]", err))
-			}
-			continue
 		}
 	}
 

--- a/service/refund_test.go
+++ b/service/refund_test.go
@@ -892,7 +892,7 @@ func TestUnitProcessPendingRefunds(t *testing.T) {
 
 	Convey("No payments with paid status found in DB", t, func() {
 		mockDao.EXPECT().GetPaymentsWithRefundPendingStatus().Return([]models.PaymentResourceDB{}, nil)
-		mockDao.EXPECT().PatchRefundReconciliationFailedStatus(gomock.Any(), gomock.Any()).Return(models.PaymentResourceDB{}, nil)
+		mockDao.EXPECT().IncrementRefundAttempts(gomock.Any(), gomock.Any()).Return(nil)
 
 		_, Success, errs := service.ProcessPendingRefunds(req)
 
@@ -1364,7 +1364,7 @@ func TestUnitCheckGovPayAndUpdateRefundStatus(t *testing.T) {
 	Convey("Process pending refunds payments status with payments", t, func() {
 		paymentsPaidDatas = append(paymentsPaidDatas, paymentsPaidData)
 		mockDao.EXPECT().GetPaymentResource(gomock.Any()).Return(&paymentsPaidData, nil)
-		mockDao.EXPECT().PatchRefundReconciliationFailedStatus(gomock.Any(), gomock.Any()).Return(models.PaymentResourceDB{}, nil).AnyTimes()
+		mockDao.EXPECT().IncrementRefundAttempts(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		updatedPayments := service.checkGovPayAndUpdateRefundStatus(req, paymentsPaidDatas)
 		So(len(updatedPayments), ShouldBeZeroValue)


### PR DESCRIPTION
Remove `refund-reconciliation-failed` status to enable retrying of refunds after network failure

BI-12802

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__