### PR TITLE
fix docker start when connecting to multiple brokers

### DIFF
--- a/ecs-image-build/docker_start.sh
+++ b/ecs-image-build/docker_start.sh
@@ -3,4 +3,10 @@
 # Start script for payments-api
 PORT="20188"
 
-exec ./payments.api.ch.gov.uk "-bind-addr=:${PORT}"
+# Read brokers and topics from environment and split on comma
+IFS=',' read -ra BROKERS <<< "${KAFKA_BROKER_ADDR}"
+
+# Ensure we only populate the broker address and topic via application arguments
+unset KAFKA_BROKER_ADDR
+
+exec ./payments.api.ch.gov.uk "-bind-addr=:${PORT}" $(for broker in "${BROKERS[@]}"; do echo -n "-broker-addr=${broker} "; done)


### PR DESCRIPTION
Fix the ecs docker_start file so it can connect to multiple kafka brokers addresses