### PR TITLE
Fix duplicate language query param in redirect URL

### DIFF
--- a/handlers/kafka_helper.go
+++ b/handlers/kafka_helper.go
@@ -41,6 +41,7 @@ func redirectUser(w http.ResponseWriter, r *http.Request, redirectURI string, pa
 	// Redirect the user to the redirect_uri, passing the state, ref and status as query params
 	redirectURL, err := url.Parse(redirectURI)
 	if err != nil {
+		log.ErrorR(r, err, log.Data{"redirect_uri": redirectURI})
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/handlers/kafka_helper.go
+++ b/handlers/kafka_helper.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/companieshouse/chs.go/avro"
 	"github.com/companieshouse/chs.go/avro/schema"
@@ -31,24 +32,28 @@ func produceRefundMessage(paymentID string, refundID string) error {
 	return produceKafkaMessage(paymentID, refundID)
 }
 
+// IMPORTANT:
+// redirectURI already contains query params in some flows.
+// String concatenation caused duplicate '?' and broken redirects.
+// Always parse and rebuild using url.Parse + RawQuery.
 // redirectUser redirects user to the provided redirect_uri with query params
 func redirectUser(w http.ResponseWriter, r *http.Request, redirectURI string, params models.RedirectParams) {
 	// Redirect the user to the redirect_uri, passing the state, ref and status as query params
-	req, err := http.NewRequest("GET", redirectURI, nil)
+	redirectURL, err := url.Parse(redirectURI)
 	if err != nil {
-		log.ErrorR(req, fmt.Errorf("error redirecting user: [%s]", err))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	query := req.URL.Query()
+
+	query := redirectURL.Query()
 	query.Add("state", params.State)
 	query.Add("ref", params.Ref)
 	query.Add("status", params.Status)
 
-	generatedURL := fmt.Sprintf("%s?%s", redirectURI, query.Encode())
-	log.InfoR(r, "Redirecting to:", log.Data{"generated_url": generatedURL})
+	redirectURL.RawQuery = query.Encode()
 
-	http.Redirect(w, r, generatedURL, http.StatusSeeOther)
+	http.Redirect(w, r, redirectURL.String(), http.StatusSeeOther)
+
 }
 
 // produceKafkaMessage handles creating a producer, marshalling the payment id into the correct avro schema and sending

--- a/handlers/redirect_user_test.go
+++ b/handlers/redirect_user_test.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/companieshouse/payments.api.ch.gov.uk/models"
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestRedirectUser_NoDuplicateQuery(t *testing.T) {
+	convey.Convey("redirectUser should preserve existing query params without duplication", t, func() {
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/", nil)
+
+		redirectURI := "http://dummy-url?lang=cy"
+
+		params := models.RedirectParams{
+			State:  "abc",
+			Ref:    "123",
+			Status: "paid",
+		}
+
+		redirectUser(w, r, redirectURI, params)
+
+		location := w.Header().Get("Location")
+
+		convey.So(strings.Count(location, "?"), convey.ShouldEqual, 1)
+		convey.So(strings.Count(location, "lang=cy"), convey.ShouldEqual, 1)
+	})
+}


### PR DESCRIPTION
Fix duplicate language query param in redirect URL



__BI-14731__

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/go.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/golang/go/wiki/CodeReviewComments)__